### PR TITLE
docs: Update repository references to cosai-oasis/project-codeguard

### DIFF
--- a/docs/claude-code-skill-plugin.md
+++ b/docs/claude-code-skill-plugin.md
@@ -21,7 +21,7 @@ Agent Skills are model-invoked capabilities that Claude autonomously uses based 
 
 1. **Add the Project CodeGuard marketplace:**
    ```bash
-   /plugin marketplace add project-codeguard/rules
+   /plugin marketplace add cosai-oasis/project-codeguard
    ```
 
 2. **Install the security plugin:**
@@ -135,7 +135,7 @@ For organizations, deploy CodeGuard to all developers automatically:
 1. Add to your project's `.claude/settings.json`:
    ```json
    {
-     "marketplaces": [{"source": "project-codeguard/rules"}],
+     "marketplaces": [{"source": "cosai-oasis/project-codeguard"}],
      "plugins": [
        {
          "name": "codeguard-security",
@@ -281,7 +281,7 @@ Look for `codeguard-security@project-codeguard` and note the version number.
 If you're contributing to Project CodeGuard or need to rebuild the plugin:
 
 ```bash
-cd /path/to/project-codeguard/rules
+cd /path/to/cosai-oasis/project-codeguard
 
 # Regenerate the Claude Code plugin (always uses core rules only)
 uv run python src/convert_to_ide_formats.py
@@ -331,7 +331,7 @@ Use CodeGuard rules to guide the architecture.
 ### File Structure
 
 ```
-project-codeguard/rules/
+cosai-oasis/project-codeguard/
 ├── .claude-plugin/
 │   ├── plugin.json                  # Plugin metadata
 │   └── marketplace.json             # Marketplace catalog
@@ -378,9 +378,9 @@ When you write or review code, Claude follows this workflow:
 
 Found an issue with the plugin or want to improve it?
 
-1. **Report issues**: [GitHub Issues](https://github.com/project-codeguard/rules/issues)
-2. **Suggest rules**: [GitHub Discussions](https://github.com/project-codeguard/rules/discussions)
-3. **Contribute**: [Contributing Guide](https://github.com/project-codeguard/rules/blob/main/CONTRIBUTING.md)
+1. **Report issues**: [GitHub Issues](https://github.com/cosai-oasis/project-codeguard/issues)
+2. **Suggest rules**: [GitHub Discussions](https://github.com/cosai-oasis/project-codeguard/discussions)
+3. **Contribute**: [Contributing Guide](https://github.com/cosai-oasis/project-codeguard/blob/main/CONTRIBUTING.md)
 
 ## Version History
 
@@ -400,9 +400,9 @@ Found an issue with the plugin or want to improve it?
 ## Resources
 
 - **Project Website**: [https://project-codeguard.org](https://project-codeguard.org)
-- **GitHub Repository**: [https://github.com/project-codeguard/rules](https://github.com/project-codeguard/rules)
+- **GitHub Repository**: [https://github.com/cosai-oasis/project-codeguard](https://github.com/cosai-oasis/project-codeguard)
 - **Documentation**: [https://project-codeguard.org/getting-started/](https://project-codeguard.org/getting-started/)
-- **Issue Tracker**: [https://github.com/project-codeguard/rules/issues](https://github.com/project-codeguard/rules/issues)
+- **Issue Tracker**: [https://github.com/cosai-oasis/project-codeguard/issues](https://github.com/cosai-oasis/project-codeguard/issues)
 
 ## License
 
@@ -414,7 +414,7 @@ Found an issue with the plugin or want to improve it?
 Need help? We're here for you:
 
 1. **Documentation**: Start with [Getting Started Guide](https://project-codeguard.org/getting-started/)
-2. **Community**: Join [GitHub Discussions](https://github.com/project-codeguard/rules/discussions)
-3. **Issues**: Report bugs via [GitHub Issues](https://github.com/project-codeguard/rules/issues)
+2. **Community**: Join [GitHub Discussions](https://github.com/cosai-oasis/project-codeguard/discussions)
+3. **Issues**: Report bugs via [GitHub Issues](https://github.com/cosai-oasis/project-codeguard/issues)
 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ This FAQ document provides clear, concise answers to help developers seamlessly 
 
 ## Q: Where can I access the rules?
 
-**A:** You can access the rules in the [Project CodeGuard GitHub repository](https://github.com/project-codeguard/rules). The latest stable release is available on the [releases page](https://github.com/project-codeguard/rules/releases).
+**A:** You can access the rules in the [Project CodeGuard GitHub repository](https://github.com/cosai-oasis/project-codeguard). The latest stable release is available on the [releases page](https://github.com/cosai-oasis/project-codeguard/releases).
 
 ---
 
@@ -16,7 +16,7 @@ This FAQ document provides clear, concise answers to help developers seamlessly 
 
 **A:** Detailed installation instructions are available in our [Getting Started guide](getting-started.md). In summary:
 
-1. Download the latest release from the [releases page](https://github.com/project-codeguard/rules/releases)
+1. Download the latest release from the [releases page](https://github.com/cosai-oasis/project-codeguard/releases)
 2. Extract the archive and copy the IDE-specific rules to your project:
    - **Cursor**: Copy `.cursor/` directory to your project root
    - **Windsurf**: Copy `.windsurf/` directory to your project root
@@ -50,7 +50,7 @@ This FAQ document provides clear, concise answers to help developers seamlessly 
 
 ## Q: How can I use the rules in my own AI agent?
 
-**A:** You can use the rules in your own AI agent by creating a custom ruleset. You can create a custom ruleset by creating a new file in the `.cursor/rules`, `.windsurf/rules`, `.github/instructions`, or `.agent/rules` directories and adding the rules you want to apply. You can also use the `project-codeguard/rules` repository as a template to create your own ruleset.
+**A:** You can use the rules in your own AI agent by creating a custom ruleset. You can create a custom ruleset by creating a new file in the `.cursor/rules`, `.windsurf/rules`, `.github/instructions`, or `.agent/rules` directories and adding the rules you want to apply. You can also use the `cosai-oasis/project-codeguard` repository as a template to create your own ruleset.
 
 ---
 
@@ -85,7 +85,7 @@ Once hidden files are visible, you can copy the appropriate directory (`.cursor/
 **A:** Yes! Install the Project CodeGuard Claude Code plugin (Agent Skill) and Claude will apply the security rules automatically while you code.
 
 ```bash
-/plugin marketplace add project-codeguard/rules
+/plugin marketplace add cosai-oasis/project-codeguard
 /plugin install codeguard-security@project-codeguard
 ```
 
@@ -96,7 +96,7 @@ For team/repo defaults, add the plugin in `.claude/settings.json` so it’s enab
 
 **A:** You can report problems, successes, or suggest enhancements to any of the rules by:
 
-1. **Creating a GitHub issue**: [Open an issue here](https://github.com/project-codeguard/rules/issues)
+1. **Creating a GitHub issue**: [Open an issue here](https://github.com/cosai-oasis/project-codeguard/issues)
 2. **Provide details**: Include which rule(s) are affected, the issue you encountered, and your suggested improvement
 3. **Be specific**: If reporting a bug, include steps to reproduce and example code if possible
 
@@ -113,7 +113,7 @@ We welcome all feedback - whether it's a bug report, success story, or enhanceme
 3. **Participating in discussions**: Share your experience and help other users
 4. **Improving documentation**: Help make our docs clearer and more comprehensive
 
-See [CONTRIBUTING.md](https://github.com/project-codeguard/rules/blob/main/CONTRIBUTING.md) for detailed guidelines on our contribution process.
+See [CONTRIBUTING.md](https://github.com/cosai-oasis/project-codeguard/blob/main/CONTRIBUTING.md) for detailed guidelines on our contribution process.
 
 ---
 
@@ -127,8 +127,8 @@ See [CONTRIBUTING.md](https://github.com/project-codeguard/rules/blob/main/CONTR
 
 **Can't find your answer?** 
 
-- [Open an issue](https://github.com/project-codeguard/rules/issues) with your question
-- [Start a discussion](https://github.com/project-codeguard/rules/discussions) to chat with the community
+- [Open an issue](https://github.com/cosai-oasis/project-codeguard/issues) with your question
+- [Start a discussion](https://github.com/cosai-oasis/project-codeguard/discussions) to chat with the community
 
 
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ Before you begin, familiarize yourself with how rules work in your IDE:
 
 ### Option 1: Download Pre-built Rules (Recommended)
 
-1. **Download**: Visit the [Releases page](https://github.com/project-codeguard/rules/releases) and download the IDE-specific ZIP file:
+1. **Download**: Visit the [Releases page](https://github.com/cosai-oasis/project-codeguard/releases) and download the IDE-specific ZIP file:
     - `ide-rules-all.zip` - All IDE formats (recommended for teams using multiple tools)
     - `ide-rules-cursor.zip` - Cursor only
     - `ide-rules-windsurf.zip` - Windsurf only
@@ -69,7 +69,7 @@ Claude Code uses a plugin system instead of manual file installation:
 
 ```bash
 # Add the Project CodeGuard marketplace
-/plugin marketplace add project-codeguard/rules
+/plugin marketplace add cosai-oasis/project-codeguard
 
 # Install the security plugin
 /plugin install codeguard-security@project-codeguard
@@ -87,7 +87,7 @@ OpenAI Codex uses [agent skills](https://agentskills.io/) to extend capabilities
 To install Project CodeGuard as a Codex skill, open Codex and use the built-in skill installer:
 
 ```
-$skill-installer install from https://github.com/project-codeguard/rules/tree/main/skills/software-security
+$skill-installer install from https://github.com/cosai-oasis/project-codeguard/tree/main/skills/software-security
 ```
 
 Alternatively, you can manually clone the skill to your project:
@@ -96,7 +96,7 @@ Alternatively, you can manually clone the skill to your project:
 # Clone to your project's .codex/skills directory
 mkdir -p .codex/skills
 cd .codex/skills
-git clone https://github.com/project-codeguard/rules.git temp
+git clone https://github.com/cosai-oasis/project-codeguard.git temp
 mv temp/skills/software-security ./
 rm -rf temp
 
@@ -114,7 +114,7 @@ If you want to customize or contribute to the rules:
 
 ```bash
 # Clone the repository
-git clone https://github.com/project-codeguard/rules.git
+git clone https://github.com/cosai-oasis/project-codeguard.git
 cd rules
 
 # Install dependencies (requires Python 3.11+)
@@ -197,8 +197,8 @@ To verify the rules are working:
 
 - **Review Rules**: Explore the security rules in your IDE's rules directory
 - **Test Integration**: Generate some code and see the security guidance in action
-- **Share Feedback**: Help us improve by [opening an issue](https://github.com/project-codeguard/rules/issues)
-- **Contribute**: See [CONTRIBUTING.md](https://github.com/project-codeguard/rules/blob/main/CONTRIBUTING.md) to contribute new rules or improvements
+- **Share Feedback**: Help us improve by [opening an issue](https://github.com/cosai-oasis/project-codeguard/issues)
+- **Contribute**: See [CONTRIBUTING.md](https://github.com/cosai-oasis/project-codeguard/blob/main/CONTRIBUTING.md) to contribute new rules or improvements
 
 !!! success "You're Ready!"
     Project CodeGuard is now protecting your development workflow. The security rules will automatically guide AI assistants to generate more secure code.
@@ -220,11 +220,11 @@ The rules have minimal performance impact, but if you experience issues:
 
 - **Reduce rule count**: Start with core rules (cryptography, input validation, authentication)
 - **Combine rules**: Merge related rules into fewer files
-- **Report issues**: Let us know via [GitHub Issues](https://github.com/project-codeguard/rules/issues)
+- **Report issues**: Let us know via [GitHub Issues](https://github.com/cosai-oasis/project-codeguard/issues)
 
 ## Getting Help
 
 - **Documentation**: You're reading it! Check the [FAQ](faq.md) for common questions
-- **GitHub Issues**: [Report bugs or ask questions](https://github.com/project-codeguard/rules/issues)
-- **Discussions**: [Join the community discussion](https://github.com/project-codeguard/rules/discussions)
+- **GitHub Issues**: [Report bugs or ask questions](https://github.com/cosai-oasis/project-codeguard/issues)
+- **Discussions**: [Join the community discussion](https://github.com/cosai-oasis/project-codeguard/discussions)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Project CodeGuard: Security Rules for AI Coding Agents
 
-[Project CodeGuard](https://github.com/project-codeguard/rules) is an open-source, model-agnostic security framework that embeds secure-by-default practices into AI coding agent workflows. It provides comprehensive security rules that guide AI assistants to generate more secure code automatically.
+[Project CodeGuard](https://github.com/cosai-oasis/project-codeguard) is an open-source, model-agnostic security framework that embeds secure-by-default practices into AI coding agent workflows. It provides comprehensive security rules that guide AI assistants to generate more secure code automatically.
 
 ## Why Project CodeGuard?
 
@@ -41,12 +41,12 @@ Our rules cover essential security domains:
 
 Get started in minutes:
 
-1. **Download the rules** from our [releases page](https://github.com/project-codeguard/rules/releases)
+1. **Download the rules** from our [releases page](https://github.com/cosai-oasis/project-codeguard/releases)
 2. **Copy to your project** - Place IDE-specific rules in your repository
 3. **Start coding** - AI assistants will automatically follow security best practices
 
 [Get Started →](getting-started.md){ .md-button .md-button--primary }
-[View on GitHub :material-github:](https://github.com/project-codeguard/rules){ .md-button }
+[View on GitHub :material-github:](https://github.com/cosai-oasis/project-codeguard){ .md-button }
 
 ## How It Works
 
@@ -57,9 +57,9 @@ Get started in minutes:
 
 ## Community
 
-- **📋 Issues**: [Report bugs or request features](https://github.com/project-codeguard/rules/issues)
-- **💬 Discussions**: [Join the conversation](https://github.com/project-codeguard/rules/discussions)
-- **🤝 Contributing**: [Learn how to contribute](https://github.com/project-codeguard/rules/blob/main/CONTRIBUTING.md)
+- **📋 Issues**: [Report bugs or request features](https://github.com/cosai-oasis/project-codeguard/issues)
+- **💬 Discussions**: [Join the conversation](https://github.com/cosai-oasis/project-codeguard/discussions)
+- **🤝 Contributing**: [Learn how to contribute](https://github.com/cosai-oasis/project-codeguard/blob/main/CONTRIBUTING.md)
 
 ## Note
 


### PR DESCRIPTION
Update all documentation references from the old repository (project-codeguard/rules) to the new CoSAI OASIS repository (cosai-oasis/project-codeguard).

Changes include:
- GitHub URLs (releases, issues, discussions, contributing)
- Git clone commands
- Plugin marketplace commands
- Skill installer commands
- JSON configuration examples
- File path references

Affected files:
- docs/index.md (6 references)
- docs/getting-started.md (10 references)
- docs/faq.md (9 references)
- docs/claude-code-skill-plugin.md (10 references)
- Fixes #15 