### PR TITLE
docs: fix gh workflow to deploy documentation website

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,10 +5,9 @@ on:
   push:
     branches:
       - main
-      - docs/deploy-website
-    # paths:
-    #   - 'docs/**'
-    #   - 'mkdocs.yml'
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Removed gh app token from the workflow since gh-pages branch is not protected.