### PR TITLE
Release v1.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "codeguard-security",
       "source": "./",
       "description": "Comprehensive security rules for AI coding agents",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "repository": "https://github.com/cosai-oasis/project-codeguard.git",
       "tags": [
         "security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codeguard-security",
   "description": "Security code review skill based on Project CodeGuard's comprehensive security rules. Helps AI coding agents write secure code and prevent common vulnerabilities.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Project CodeGuard",
     "url": "https://project-codeguard.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-codeguard"
-version = "1.3.0"
+version = "1.3.1"
 description = "AI Coding Rules for Security and Best Practices"
 requires-python = ">=3.11"
 dependencies = [

--- a/skills/software-security/SKILL.md
+++ b/skills/software-security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: software-security
 description: A software security skill that integrates with Project CodeGuard to help AI coding agents write secure code and prevent common vulnerabilities. Use this skill when writing, reviewing, or modifying code to ensure secure-by-default practices are followed.
-codeguard-version: "1.3.0"
+codeguard-version: "1.3.1"
 framework: "Project CodeGuard"
 purpose: "Embed secure-by-default practices into AI coding workflows"
 ---

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "project-codeguard"
-version = "1.3.0"
+version = "1.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "mkdocs" },


### PR DESCRIPTION
Bumps version to `1.3.1`. Rule content unchanged from v1.3.0 — packaging/tooling only.

Once merged, publishing a `v1.3.1` GitHub Release will trigger `build-ide-bundles.yml` to attach `ide-rules-codex.zip` and `ide-rules-opencode.zip` (added since v1.3.0).

Closes #33