### PR TITLE
This commit adds OpenClaw and Hermes agent framework support

### DIFF
--- a/.github/workflows/build-ide-bundles.yml
+++ b/.github/workflows/build-ide-bundles.yml
@@ -57,6 +57,8 @@ jobs:
           zip -r ../ide-rules-antigravity.zip .agent/
           zip -r ../ide-rules-opencode.zip .opencode/
           zip -r ../ide-rules-codex.zip .codex/
+          zip -r ../ide-rules-openclaw.zip .openclaw/
+          zip -r ../ide-rules-hermes.zip .hermes/
           cd ..
           zip -r ide-rules-all.zip dist/
           ls -lh ide-rules-*.zip
@@ -73,5 +75,7 @@ jobs:
             ide-rules-antigravity.zip \
             ide-rules-opencode.zip \
             ide-rules-codex.zip \
+            ide-rules-openclaw.zip \
+            ide-rules-hermes.zip \
             --clobber
 

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -103,7 +103,17 @@ jobs:
             echo "❌ Codex rules not generated"
             exit 1
           fi
-          
+
+          if [ ! -d "test-output/.openclaw" ]; then
+            echo "❌ OpenClaw rules not generated"
+            exit 1
+          fi
+
+          if [ ! -d "test-output/.hermes" ]; then
+            echo "❌ Hermes rules not generated"
+            exit 1
+          fi
+
           echo "✅ All IDE formats generated successfully"
 
       - name: Check skills/ directory is up-to-date

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,16 @@ Before you begin, familiarize yourself with how rules work in your AI coding too
 
     :material-book-open-page-variant: [OpenCode Skills Documentation](https://opencode.ai/docs/skills/)
 
+=== "OpenClaw"
+    OpenClaw uses `.openclaw/skills` for skill configuration.
+
+    :material-book-open-page-variant: [OpenClaw Documentation](https://github.com/openclaw/openclaw)
+
+=== "Hermes"
+    Hermes uses `.hermes/skills` for skill configuration.
+
+    :material-book-open-page-variant: [Hermes Skills Documentation](https://hermes-agent.nousresearch.com/docs/skills/)
+
 ## Installation
 
 ### Option 1: Install Pre-built Rules (Recommended)
@@ -201,6 +211,57 @@ Select your AI coding tool and follow the instructions:
     !!! info "Codex Skills Documentation"
         For more information, see the [OpenAI Codex Skills documentation](https://developers.openai.com/codex/skills/).
 
+=== "OpenClaw"
+
+    OpenClaw uses the [Agent Skills standard](https://agentskills.io/) for skill discovery.
+
+    **Option A: Pre-built download (recommended)**
+
+    1. **Download** [`ide-rules-openclaw.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    2. **Extract** the ZIP file
+    3. **Copy** the `.openclaw/` directory to your project root:
+
+        ```bash
+        cp -r .openclaw/ /path/to/your/project/
+        ```
+
+    4. **Start a new session** in OpenClaw to load the rules
+
+    **Option B: ClawHub marketplace**
+
+    ```bash
+    clawhub install software-security
+    ```
+
+    Once installed, OpenClaw automatically discovers and applies the security rules when generating or reviewing code.
+
+=== "Hermes"
+
+    Hermes uses the [Agent Skills standard](https://agentskills.io/) for skill discovery.
+
+    **Option A: Pre-built download (recommended)**
+
+    1. **Download** [`ide-rules-hermes.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    2. **Extract** the ZIP file
+    3. **Copy** the `.hermes/` directory to your project root:
+
+        ```bash
+        cp -r .hermes/ /path/to/your/project/
+        ```
+
+    4. **Start a new session** in Hermes to load the rules
+
+    **Option B: Hermes CLI**
+
+    ```bash
+    hermes skills install software-security
+    ```
+
+    Once installed, Hermes automatically discovers and applies the security rules when generating or reviewing code.
+
+    !!! info "Hermes Skills Documentation"
+        For more information, see the [Hermes Skills documentation](https://hermes-agent.nousresearch.com/docs/skills/).
+
 **Using multiple tools?** Download [`ide-rules-all.zip`](https://github.com/cosai-oasis/project-codeguard/releases) for all formats in one archive.
 
 !!! tip "Repository Level Installation"
@@ -240,6 +301,8 @@ cp -r dist/.github/ /path/to/your/project/
 cp -r dist/.agent/ /path/to/your/project/
 cp -r dist/.opencode/ /path/to/your/project/
 cp -r dist/.codex/ /path/to/your/project/
+cp -r dist/.openclaw/ /path/to/your/project/
+cp -r dist/.hermes/ /path/to/your/project/
 ```
 
 ## Core vs OWASP Sources
@@ -270,6 +333,8 @@ For GitHub repositories, you can automate rule updates with a workflow that runs
 - Antigravity (`.agent/rules/`)
 - OpenCode (`.opencode/skills/software-security/rules/`)
 - Codex (`.codex/skills/software-security/rules/`)
+- OpenClaw (`.openclaw/skills/software-security/rules/`)
+- Hermes (`.hermes/skills/software-security/rules/`)
 
 ### Setup
 
@@ -294,6 +359,12 @@ your-project/
 │   └── rules/
 ├── .github/
 │   └── instructions/
+├── .hermes/
+│   └── skills/
+│       └── software-security/
+├── .openclaw/
+│   └── skills/
+│       └── software-security/
 ├── .opencode/
 │   └── skills/
 │       └── software-security/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -215,8 +215,6 @@ Select your AI coding tool and follow the instructions:
 
     OpenClaw uses the [Agent Skills standard](https://agentskills.io/) for skill discovery.
 
-    **Option A: Pre-built download (recommended)**
-
     1. **Download** [`ide-rules-openclaw.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.openclaw/` directory to your project root:
@@ -227,19 +225,9 @@ Select your AI coding tool and follow the instructions:
 
     4. **Start a new session** in OpenClaw to load the rules
 
-    **Option B: ClawHub marketplace**
-
-    ```bash
-    clawhub install software-security
-    ```
-
-    Once installed, OpenClaw automatically discovers and applies the security rules when generating or reviewing code.
-
 === "Hermes"
 
     Hermes uses the [Agent Skills standard](https://agentskills.io/) for skill discovery.
-
-    **Option A: Pre-built download (recommended)**
 
     1. **Download** [`ide-rules-hermes.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
@@ -250,17 +238,6 @@ Select your AI coding tool and follow the instructions:
         ```
 
     4. **Start a new session** in Hermes to load the rules
-
-    **Option B: Hermes CLI**
-
-    ```bash
-    hermes skills install software-security
-    ```
-
-    Once installed, Hermes automatically discovers and applies the security rules when generating or reviewing code.
-
-    !!! info "Hermes Skills Documentation"
-        For more information, see the [Hermes Skills documentation](https://hermes-agent.nousresearch.com/docs/skills/).
 
 **Using multiple tools?** Download [`ide-rules-all.zip`](https://github.com/cosai-oasis/project-codeguard/releases) for all formats in one archive.
 

--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -138,7 +138,7 @@ def convert_rules(
         AntigravityFormat(version),
     ]
 
-    # Only include Agent Skills, OpenCode, and Codex formats for core rules
+    # Only include Agent Skills–based formats (skills with SKILL.md) for core rules
     if include_agentskills:
         all_formats.append(AgentSkillsFormat(version))
         all_formats.append(OpenCodeFormat(version))

--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -21,6 +21,8 @@ from formats import (
     AntigravityFormat,
     OpenCodeFormat,
     CodexFormat,
+    OpenClawFormat,
+    HermesFormat,
 )
 from utils import get_version_from_pyproject
 from validate_versions import set_plugin_version, set_marketplace_version
@@ -141,6 +143,8 @@ def convert_rules(
         all_formats.append(AgentSkillsFormat(version))
         all_formats.append(OpenCodeFormat(version))
         all_formats.append(CodexFormat(version))
+        all_formats.append(OpenClawFormat(version))
+        all_formats.append(HermesFormat(version))
 
     converter = RuleConverter(formats=all_formats)
     path = Path(input_path)
@@ -272,6 +276,18 @@ def convert_rules(
         shutil.copy2(output_skill_path, codex_skill_dir / "SKILL.md")
         print(f"Copied SKILL.md to {codex_skill_dir / 'SKILL.md'}")
 
+        # Copy SKILL.md to the OpenClaw skill directory (.openclaw/skills/software-security/).
+        openclaw_skill_dir = Path(output_dir) / ".openclaw" / "skills" / "software-security"
+        openclaw_skill_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(output_skill_path, openclaw_skill_dir / "SKILL.md")
+        print(f"Copied SKILL.md to {openclaw_skill_dir / 'SKILL.md'}")
+
+        # Copy SKILL.md to the Hermes skill directory (.hermes/skills/software-security/).
+        hermes_skill_dir = Path(output_dir) / ".hermes" / "skills" / "software-security"
+        hermes_skill_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(output_skill_path, hermes_skill_dir / "SKILL.md")
+        print(f"Copied SKILL.md to {hermes_skill_dir / 'SKILL.md'}")
+
     return results
 
 
@@ -372,7 +388,7 @@ if __name__ == "__main__":
         sources_list = ", ".join(p.name for p in source_paths)
         print(f"\nConverting {len(source_paths)} sources: {sources_list}")
         if has_core:
-            print("(Agent Skills, OpenCode, and Codex will include only core rules)")
+            print("(Agent Skills, OpenCode, Codex, OpenClaw, and Hermes will include only core rules)")
         print()
 
     # Convert all sources

--- a/src/formats/__init__.py
+++ b/src/formats/__init__.py
@@ -11,9 +11,11 @@ Available Formats:
 - AntigravityFormat: Generates .md files for Google Antigravity
 - OpenCodeFormat: Generates .md files for OpenCode AI coding agent
 - CodexFormat: Generates .md files for OpenAI Codex
+- OpenClawFormat: Generates .md files for OpenClaw AI assistant
+- HermesFormat: Generates .md files for Hermes AI coding agent
 
 Usage:
-    from formats import BaseFormat, ProcessedRule, CursorFormat, WindsurfFormat, CopilotFormat, AgentSkillsFormat, AntigravityFormat, OpenCodeFormat, CodexFormat
+    from formats import BaseFormat, ProcessedRule, CursorFormat, WindsurfFormat, CopilotFormat, AgentSkillsFormat, AntigravityFormat, OpenCodeFormat, CodexFormat, OpenClawFormat, HermesFormat
 
     version = "1.0.0"
     formats = [
@@ -24,6 +26,8 @@ Usage:
         AntigravityFormat(version),
         OpenCodeFormat(version),
         CodexFormat(version),
+        OpenClawFormat(version),
+        HermesFormat(version),
     ]
 """
 
@@ -35,6 +39,8 @@ from formats.agentskills import AgentSkillsFormat
 from formats.antigravity import AntigravityFormat
 from formats.opencode import OpenCodeFormat
 from formats.codex import CodexFormat
+from formats.openclaw import OpenClawFormat
+from formats.hermes import HermesFormat
 
 __all__ = [
     "BaseFormat",
@@ -46,4 +52,6 @@ __all__ = [
     "AntigravityFormat",
     "OpenCodeFormat",
     "CodexFormat",
+    "OpenClawFormat",
+    "HermesFormat",
 ]

--- a/src/formats/hermes.py
+++ b/src/formats/hermes.py
@@ -1,0 +1,45 @@
+"""
+Hermes Format Implementation
+
+Generates .md rule files for Hermes. The SKILL.md is copied from
+Agent Skills output (see convert_to_ide_formats.py); rule files are
+generated identically to Agent Skills via inheritance.
+
+Hermes discovers skills by scanning for SKILL.md files in directory structures
+like .hermes/skills/<skill-name>/SKILL.md. Individual rule files live in a
+rules/ subdirectory that the skill tool discovers at runtime.
+
+See: https://github.com/NousResearch/hermes-agent
+"""
+
+from formats.agentskills import AgentSkillsFormat
+
+
+class HermesFormat(AgentSkillsFormat):
+    """
+    Hermes format implementation (.md rule files).
+
+    Hermes (https://github.com/NousResearch/hermes-agent) is an AI coding
+    agent by Nous Research that discovers skills by scanning for SKILL.md
+    files in specific directory structures. Each skill must live in its own
+    named directory:
+
+        .hermes/skills/<skill-name>/SKILL.md
+
+    Individual rule files are placed in a rules/ subdirectory:
+
+        .hermes/skills/<skill-name>/rules/<rule>.md
+
+    The rule files preserve the original YAML frontmatter (description,
+    languages, alwaysApply) so rules remain complete and can be referenced
+    by the AI coding agent.
+
+    Inherits generate() from AgentSkillsFormat since the rule file format
+    is identical.
+    """
+
+    def get_format_name(self) -> str:
+        return "hermes"
+
+    def get_output_subpath(self) -> str:
+        return ".hermes/skills/software-security/rules"

--- a/src/formats/openclaw.py
+++ b/src/formats/openclaw.py
@@ -1,0 +1,44 @@
+"""
+OpenClaw Format Implementation
+
+Generates .md rule files for OpenClaw. The SKILL.md is copied from
+Agent Skills output (see convert_to_ide_formats.py); rule files are
+generated identically to Agent Skills via inheritance.
+
+OpenClaw discovers skills by scanning for SKILL.md files in directory structures
+like .openclaw/skills/<skill-name>/SKILL.md. Individual rule files live in a
+rules/ subdirectory that the skill tool discovers at runtime.
+
+See: https://github.com/openclaw/openclaw
+"""
+
+from formats.agentskills import AgentSkillsFormat
+
+
+class OpenClawFormat(AgentSkillsFormat):
+    """
+    OpenClaw format implementation (.md rule files).
+
+    OpenClaw (https://github.com/openclaw/openclaw) is an AI assistant that
+    discovers skills by scanning for SKILL.md files in specific directory
+    structures. Each skill must live in its own named directory:
+
+        .openclaw/skills/<skill-name>/SKILL.md
+
+    Individual rule files are placed in a rules/ subdirectory:
+
+        .openclaw/skills/<skill-name>/rules/<rule>.md
+
+    The rule files preserve the original YAML frontmatter (description,
+    languages, alwaysApply) so rules remain complete and can be referenced
+    by the AI coding agent.
+
+    Inherits generate() from AgentSkillsFormat since the rule file format
+    is identical.
+    """
+
+    def get_format_name(self) -> str:
+        return "openclaw"
+
+    def get_output_subpath(self) -> str:
+        return ".openclaw/skills/software-security/rules"


### PR DESCRIPTION
Both frameworks follow the Agent Skills standard (agentskills.io) and use SKILL.md discovery, so the new format classes inherit from AgentSkillsFormat (identical pattern to Codex/OpenCode).

Changes:
- New format classes: OpenClawFormat, HermesFormat
- Converter pipeline generates .openclaw/ and .hermes/ output dirs
- CI workflows: build zips + validate generation for both
- Docs: installation tabs for both in getting-started.md