### PR TITLE
Add release version badge to homepage and verify OpenCode install paths

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Project CodeGuard: Security Skills and Rules for AI Coding Agents
 
+[![Latest Release](https://img.shields.io/github/v/release/cosai-oasis/project-codeguard)](https://github.com/cosai-oasis/project-codeguard/releases/latest)
+
 [Project CodeGuard](https://github.com/cosai-oasis/project-codeguard) is an open-source, model-agnostic security framework that embeds secure-by-default practices into AI coding agent workflows. It provides comprehensive security rules that guide AI assistants to generate more secure code automatically.
 
 ## Why Project CodeGuard?


### PR DESCRIPTION
Verification issues from #63 

## Changes

**`docs/index.md`**
- Add dynamic GitHub releases badge so the homepage always reflects the current release version

## Verification
- Verified OpenCode install path (`.opencode/skills/`) against [OpenCode Skills docs](https://opencode.ai/docs/skills/)
- Verified `opencode.json` schema and `instructions` field against [OpenCode Rules docs](https://opencode.ai/docs/rules/)