### PR TITLE
Add docs pages for MCP server, CodeGuard Reviewer, and authored skills

### DIFF
--- a/docs/codeguard-reviewer.md
+++ b/docs/codeguard-reviewer.md
@@ -1,0 +1,111 @@
+# CodeGuard Reviewer
+
+The CodeGuard Reviewer is a subagent that performs a full security scan of a repository against all CodeGuard rules and emits findings as a [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) file. It is read-only on your source — the only file it writes is the SARIF output.
+
+!!! warning "Use for explicit security scans only"
+    The reviewer is designed for on-demand security scans, not continuous code generation. It activates when you explicitly ask for a security scan, security review, SARIF output, or CodeGuard compliance check. It does **not** activate for general code writing or editing.
+
+## Supported Hosts
+
+The CodeGuard Reviewer subagent is currently emitted for:
+
+| Host | Agent file location |
+|:-----|:-------------------|
+| **Claude Code** | `.claude/agents/codeguard-reviewer.md` |
+| **Cursor** | `.cursor/agents/codeguard-reviewer.md` |
+
+## How to Invoke
+
+=== "Claude Code"
+
+    Ask Claude directly in your session:
+
+    ```
+    Run a CodeGuard security review of this repository
+    ```
+
+    Or request SARIF output explicitly:
+
+    ```
+    Perform a CodeGuard compliance check and emit SARIF output
+    ```
+
+=== "Cursor"
+
+    In the Cursor chat panel:
+
+    ```
+    Run a security scan using the CodeGuard reviewer
+    ```
+
+## What It Does
+
+The reviewer follows a five-step workflow:
+
+**1. Detect languages**
+
+Identifies languages present in the repository using file extensions and manifest files (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pom.xml`, `build.gradle`, `composer.json`, `Gemfile`, etc.).
+
+**2. Load rules**
+
+Lists all `codeguard-*` rule files. Each rule's frontmatter declares applicability via `languages:` or `globs:`. Rules with neither field always apply; rules that don't match the repo's languages are skipped and noted as "not applicable".
+
+**3. Search for violations**
+
+For each applicable rule, searches the repository for candidate violations using patterns derived from the rule body (banned APIs, required configurations, example violations). The following paths are always excluded from search:
+
+- Rule directories (`.claude/`, `.cursor/`, `.codex/`, `.agents/`, `.opencode/`, `.windsurf/`, `.github/instructions/`, `.openclaw/`, `.hermes/`)
+- Vendored/generated paths (`.git/`, `node_modules/`, `vendor/`, `.venv/`, `venv/`, `dist/`, `build/`, `target/`)
+- Any path excluded by `.gitignore`
+
+**4. Triage findings**
+
+Every candidate is classified as:
+
+| Class | SARIF output | Description |
+|:------|:------------|:------------|
+| `confirmed` | Included | Actionable finding, re-verified at the exact line |
+| `needs-human` | Included | Potential issue requiring human judgement |
+| `false-positive` | Excluded | Discarded, with a one-line justification in the summary |
+
+**5. Emit SARIF and summary**
+
+Writes `codeguard-findings-<UTC_TIMESTAMP>.sarif` to the repository root (e.g. `codeguard-findings-20260420T183005Z.sarif`). Timestamps use ISO-8601 basic UTC format so fast reruns don't collide.
+
+Returns a structured markdown summary containing:
+
+- Counts by result class (`confirmed`, `needs-human`, `false-positive`)
+- Rules checked vs. rules skipped (not applicable)
+- Top 5 files by confirmed-finding count with `file:line` references
+- One-line justification for each false-positive group discarded
+
+## SARIF Output Format
+
+The emitted SARIF 2.1.0 file follows this structure:
+
+- `version`: `"2.1.0"`
+- `tool.driver.name`: `"CodeGuard Security Reviewer"`
+- `tool.driver.rules[]`: populated from the full rule set (id, shortDescription)
+- `results[]`: one entry per `confirmed` or `needs-human` finding that survived re-verification
+
+Each result includes:
+
+| Field | Value |
+|:------|:------|
+| `ruleId` | Matches a `tool.driver.rules[].id` |
+| `level` | `error` (confirmed `codeguard-1-*`), `warning` (confirmed `codeguard-0-*`), `note` (all `needs-human`) |
+| `message.text` | Concrete, actionable description citing the rule |
+| `locations[0].physicalLocation.artifactLocation.uri` | Repo-relative file path |
+| `locations[0].physicalLocation.region.startLine` | 1-indexed line number |
+
+## Constraints
+
+- **Read-only** on repository source — the SARIF findings file is the only write
+- Never executes code discovered in the target repository
+- If the rule bundle is missing or empty, stops and reports the issue — does not fabricate rule content
+- If the target repository is empty, still emits a valid SARIF run with an empty `results[]` array
+
+## Next Steps
+
+[Getting Started →](getting-started.md){ .md-button .md-button--primary }
+[Choosing an Install Path →](install-paths.md){ .md-button }

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,125 @@
+# CodeGuard MCP Server
+
+The CodeGuard MCP server exposes all 23 core security rules as individual [Model Context Protocol](https://modelcontextprotocol.io/) tools over streamable HTTP. Deploy it once on your infrastructure and every AI coding assistant in your organization gets access to the same curated, versioned security guidance — no per-repo file installation needed.
+
+!!! info "When to use the MCP server"
+    The MCP server is best suited for teams that already operate MCP infrastructure and want a single, centrally managed source of CodeGuard rules. For most individual users and teams, [rule files or Agent Skills](install-paths.md) are simpler. See [Choosing an Install Path](install-paths.md#mcp-server) for a full comparison.
+
+## Quick Start
+
+### Run locally with uv
+
+```bash
+cd src/codeguard-mcp
+uv sync
+uv run fastmcp run src/codeguard_mcp/server.py:mcp \
+    --transport streamable-http --host 0.0.0.0 --port 8080
+```
+
+### Docker
+
+```bash
+cd src/codeguard-mcp
+docker compose up --build
+```
+
+## Connect Your IDE
+
+Add the server to your MCP client configuration:
+
+=== "Local"
+
+    ```json
+    {
+      "mcpServers": {
+        "codeguard": {
+          "url": "http://localhost:8080/mcp"
+        }
+      }
+    }
+    ```
+
+=== "Org-wide"
+
+    Put the server behind a reverse proxy with TLS and SSO, then point every developer's IDE at the internal URL:
+
+    ```json
+    {
+      "mcpServers": {
+        "codeguard": {
+          "url": "https://codeguard-mcp.internal.company.com/mcp"
+        }
+      }
+    }
+    ```
+
+## Install the Meta Skill
+
+The meta skill tells your AI assistant how to use the CodeGuard MCP tools. It lives at `.agents/skills/codeguard-mcp-meta/SKILL.md` and needs to be installed in your project.
+
+=== "Copy from repo"
+
+    ```bash
+    cp -r src/codeguard-mcp/.agents /path/to/your/project/
+    ```
+
+=== "Download from server"
+
+    ```bash
+    curl -o codeguard-meta-skill.zip http://localhost:8080/download/skill
+    unzip codeguard-meta-skill.zip -d /path/to/your/project/
+    ```
+
+    The `/download/skill` endpoint returns a zip containing the `.agents/` directory. Unzip it into your project root.
+
+## How It Works
+
+The server reads the 23 security rules from `sources/rules/core/` and registers each one as a no-argument MCP tool. When your AI assistant generates or reviews code, it invokes the relevant tools and applies the returned guidance.
+
+```
+Developer writes code
+        ↓
+AI assistant reads the meta skill
+        ↓
+Invokes codeguard_1_* tools (always-on guardrails)
+        ↓
+Invokes codeguard_0_* tools (context-selected by language + domain)
+        ↓
+Applies security guidance to generated code
+        ↓
+Documents which rules were applied
+```
+
+### Tool Taxonomy
+
+| Prefix | When invoked | Count | Examples |
+|:-------|:------------|:------|:--------|
+| `codeguard_1_*` | **Always** — before any code change | 3 | `codeguard_1_hardcoded_credentials`, `codeguard_1_crypto_algorithms` |
+| `codeguard_0_*` | **Context-selected** by language and domain | 20 | `codeguard_0_input_validation_injection`, `codeguard_0_api_web_services` |
+
+## Configuration
+
+All settings are controlled via environment variables with the `CODEGUARD_` prefix:
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `CODEGUARD_HOST` | `0.0.0.0` | Bind address |
+| `CODEGUARD_PORT` | `8080` | Bind port |
+| `CODEGUARD_LOG_LEVEL` | `INFO` | Log level |
+| `CODEGUARD_TRANSPORT` | `streamable-http` | `streamable-http` or `stdio` |
+| `CODEGUARD_RULES_DIR` | `sources/rules/core/` | Path to rule markdown files |
+
+Copy `.env.example` from `src/codeguard-mcp/` to `.env` and edit as needed before running.
+
+## Endpoints
+
+| Method | Path | Description |
+|:-------|:-----|:------------|
+| `POST` | `/mcp` | MCP protocol endpoint |
+| `GET` | `/health` | Health check — returns `{"status": "ok", "version": "..."}` |
+| `GET` | `/download/skill` | Download the meta skill as a `.agents/` zip |
+
+## Next Steps
+
+[Choosing an Install Path →](install-paths.md){ .md-button .md-button--primary }
+[Getting Started →](getting-started.md){ .md-button }

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # CodeGuard MCP Server
 
-The CodeGuard MCP server exposes all 23 core security rules as individual [Model Context Protocol](https://modelcontextprotocol.io/) tools over streamable HTTP. Deploy it once on your infrastructure and every AI coding assistant in your organization gets access to the same curated, versioned security guidance — no per-repo file installation needed.
+The CodeGuard MCP server exposes all 23 core security rules as individual [Model Context Protocol](https://modelcontextprotocol.io/) tools over streamable HTTP. Deploy it once on your infrastructure and every AI coding assistant in your organization gets access to the same curated, versioned security guidance — no per-repo rule bundle installation needed.
 
 !!! info "When to use the MCP server"
     The MCP server is best suited for teams that already operate MCP infrastructure and want a single, centrally managed source of CodeGuard rules. For most individual users and teams, [rule files or Agent Skills](install-paths.md) are simpler. See [Choosing an Install Path](install-paths.md#mcp-server) for a full comparison.
@@ -109,7 +109,7 @@ All settings are controlled via environment variables with the `CODEGUARD_` pref
 | `CODEGUARD_TRANSPORT` | `streamable-http` | `streamable-http` or `stdio` |
 | `CODEGUARD_RULES_DIR` | `sources/rules/core/` | Path to rule markdown files |
 
-Copy `.env.example` from `src/codeguard-mcp/` to `.env` and edit as needed before running.
+Set these as environment variables in your shell before running, for example `export CODEGUARD_PORT=9090`.
 
 ## Endpoints
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,105 @@
+# Authored Skills
+
+Project CodeGuard ships two authored skills in `sources/skills/` that go beyond the core security rules. Unlike the generated rule files, these skills define complete workflows — they tell the AI assistant not just *what* to check, but *how* to carry out a multi-step task.
+
+| Skill | What it does |
+|:------|:------------|
+| [`security-review`](#security-review) | Full codebase security review producing a structured markdown report |
+| [`memory-safe-migration`](#memory-safe-migration) | Guided migration of C/C++ code to a memory-safe language |
+
+Both skills are included in the Claude Code plugin and are available in `sources/skills/` for use with other agents.
+
+---
+
+## Security Review
+
+**Skill file:** `sources/skills/security-review/SKILL.md`
+
+Performs a comprehensive security review of a target repository and produces a formal markdown report with prioritized findings and remediation guidance. The skill loads all 23 CodeGuard core rules plus relevant OWASP supplementary rules for the detected tech stack.
+
+### When to use
+
+Use when you want a full, structured security audit of a codebase — not for inline code generation. This produces a standalone report, not inline code suggestions.
+
+### How to trigger
+
+Ask your AI assistant to perform a security review, for example:
+
+```
+Review this repository for security issues and produce a report
+```
+
+If the repository path is ambiguous, the skill will ask for it before proceeding.
+
+### What the report includes
+
+- **Executive Summary** — total findings by severity (Critical / High / Medium / Low / Info), top 5 issues, overall security posture
+- **Detailed Findings** — for each issue: title, severity, rule reference, location, code snippet, description, impact, remediation with examples, and references
+- **Findings by Category** — grouped view across all findings
+- **Recommendations** — immediate actions, short-term (1–3 months), long-term improvements, tooling and process suggestions
+- **Appendix** — files reviewed, rules applied, methodology notes
+
+### Output location
+
+Reports are saved to:
+
+```
+./security_report/sec_review_<repo-name>_<YYYY-MM-DD_HH-mm-ss>.md
+```
+
+---
+
+## Memory-Safe Migration
+
+**Skill file:** `sources/skills/memory-safe-migration/SKILL.md`
+
+Guides secure migration of code from memory-unsafe languages (C, C++, Assembly) to memory-safe alternatives (Rust, Go, Java, C#, Swift). Also activates when an AI agent is about to generate new C/C++ code that could be written in a memory-safe language instead.
+
+### When it activates
+
+- Migrating, porting, or rewriting C/C++ code to Rust, Go, Java, C#, or Swift
+- Adding a new module or feature to an existing C/C++ project
+- Designing an FFI boundary between safe and unsafe code
+- Reviewing mixed-language code for memory safety issues
+- Discussing memory safety roadmaps or CISA/NSA compliance
+- AI agent is about to generate new C/C++ code
+
+### Migration workflow
+
+The skill follows a six-step process:
+
+1. **Assess** — evaluate migration priority and feasibility using `scripts/assess-migration.py` or the assessment checklist
+2. **Write tests first** — establish a correctness oracle against the C/C++ implementation before touching anything
+3. **Migrate incrementally** — one function or module at a time; never rewrite an entire codebase in one pass
+4. **Secure the FFI boundary** — validate all inputs from the unsafe side, minimize `unsafe` blocks, document every `unsafe` block with a `// SAFETY:` comment
+5. **Validate** — run existing tests, fuzz FFI boundaries, check memory safety tools (Miri, race detector, ASan), benchmark performance
+6. **Update build and CI** — integrate the memory-safe toolchain, add linting and formatting checks, add safety-specific CI steps
+
+### Migration priority order
+
+| Priority | Code type |
+|:---------|:----------|
+| 1 | Network-facing code (parsers, protocol handlers, TLS) |
+| 2 | Code handling untrusted input (file parsers, deserialization) |
+| 3 | Cryptographic implementations |
+| 4 | Privilege boundary code (auth enforcement) |
+| 5 | Code with a history of memory-related CVEs |
+| 6 | Internal utility code |
+
+### Reference documents
+
+The skill bundles detailed reference docs in `sources/skills/memory-safe-migration/references/`:
+
+| Document | Contents |
+|:---------|:---------|
+| `language-selection.md` | Guide for choosing between Rust, Go, Java, C#, and Swift |
+| `ffi-security.md` | Rules for securing FFI boundaries between safe and unsafe code |
+| `migration-patterns.md` | Common patterns for buffers, strings, concurrency, and error handling |
+| `assessment-checklist.md` | Checklist for evaluating migration priority and feasibility |
+
+---
+
+## Next Steps
+
+[Getting Started →](getting-started.md){ .md-button .md-button--primary }
+[Custom Rules →](custom-rules.md){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,9 @@ nav:
   - Choosing an Install Path: install-paths.md
   - CoSAI Personas: personas.md
   - Claude Code Plugin: claude-code-skill-plugin.md
+  - MCP Server: mcp-server.md
+  - CodeGuard Reviewer: codeguard-reviewer.md
+  - Skills: skills.md
   - Custom Rules: custom-rules.md
   - FAQ: faq.md
 markdown_extensions:


### PR DESCRIPTION
Add Pages as outlined in #63 

## Changes

**`docs/mcp-server.md`** (new)
- Setup instructions (uv and Docker)
- IDE connection config for local and org-wide deployment
- Meta skill installation
- Tool taxonomy, configuration reference, and endpoints

**`docs/codeguard-reviewer.md`** (new)
- Supported hosts (Claude Code and Cursor)
- How to invoke per host
- Five-step scan workflow
- SARIF 2.1.0 output format and constraints

**`docs/skills.md`** (new)
- `security-review` skill — workflow, report structure, output location
- `memory-safe-migration` skill — activation triggers, six-step migration workflow, priority order, reference docs

**`mkdocs.yml`**
- Added all three pages to the nav