### PR TITLE
Feature: Tag-Based Rule Mapping for Improved AI Model Adherence

### DIFF
--- a/skills/software-security/SKILL.md
+++ b/skills/software-security/SKILL.md
@@ -24,7 +24,20 @@ When writing or reviewing code:
 - `codeguard-1-hardcoded-credentials.md` - Never hardcode secrets, passwords, API keys, or tokens
 - `codeguard-1-crypto-algorithms.md` - Use only modern, secure cryptographic algorithms
 - `codeguard-1-digital-certificates.md` - Validate and manage digital certificates securely
-2. Context-Specific Rules: Apply rules from /rules directory based on the language of the feature being implemented using the table given below:
+2. Tag-Based Rules: When you identify any of these security contexts in the code, apply ALL rules with the matching tag:
+
+
+| Security Context (Tag) | Rule Files to Apply |
+|------------------------|---------------------|
+| authentication | codeguard-0-authentication-mfa.md, codeguard-0-session-management-and-cookies.md |
+| data-security | codeguard-0-additional-cryptography.md, codeguard-0-data-storage.md |
+| infrastructure | codeguard-0-cloud-orchestration-kubernetes.md, codeguard-0-data-storage.md, codeguard-0-devops-ci-cd-containers.md, codeguard-0-iac-security.md |
+| privacy | codeguard-0-logging.md, codeguard-0-privacy-data-protection.md |
+| secrets | codeguard-0-additional-cryptography.md, codeguard-1-digital-certificates.md, codeguard-1-hardcoded-credentials.md |
+| web | codeguard-0-api-web-services.md, codeguard-0-authentication-mfa.md, codeguard-0-client-side-web-security.md, codeguard-0-input-validation-injection.md, codeguard-0-session-management-and-cookies.md |
+
+
+3. Language-Specific Rules: Apply rules from /rules directory based on the programming language of the feature being implemented using the table given below:
 
 
 | Language | Rule Files to Apply |
@@ -55,7 +68,7 @@ When writing or reviewing code:
 | yaml | codeguard-0-additional-cryptography.md, codeguard-0-api-web-services.md, codeguard-0-authorization-access-control.md, codeguard-0-cloud-orchestration-kubernetes.md, codeguard-0-data-storage.md, codeguard-0-devops-ci-cd-containers.md, codeguard-0-framework-and-languages.md, codeguard-0-iac-security.md, codeguard-0-logging.md, codeguard-0-privacy-data-protection.md, codeguard-0-supply-chain-security.md |
 
 
-3. Proactive Security: Don't just avoid vulnerabilities-actively implement secure patterns:
+4. Proactive Security: Don't just avoid vulnerabilities-actively implement secure patterns:
 - Use parameterized queries for database access
 - Validate and sanitize all user input
 - Apply least-privilege principles
@@ -71,8 +84,8 @@ When generating or reviewing code, follow this workflow:
 ### 1. Initial Security Check
 Before writing any code:
 - Check: Will this handle credentials? → Apply codeguard-1-hardcoded-credentials
+- Check: What security tags apply? → Load all rules with matching tags (e.g., "authentication", "web", "secrets")
 - Check: What language am I using? → Identify applicable language-specific rules
-- Check: What security domains are involved? → Load relevant rule files
 
 ### 2. Code Generation
 While writing code:

--- a/skills/software-security/rules/codeguard-0-additional-cryptography.md
+++ b/skills/software-security/rules/codeguard-0-additional-cryptography.md
@@ -15,6 +15,9 @@ languages:
 - xml
 - yaml
 alwaysApply: false
+tags:
+- data-security
+- secrets
 ---
 
 rule_id: codeguard-0-additional-cryptography

--- a/skills/software-security/rules/codeguard-0-api-web-services.md
+++ b/skills/software-security/rules/codeguard-0-api-web-services.md
@@ -12,6 +12,8 @@ languages:
 - xml
 - yaml
 alwaysApply: false
+tags:
+- web
 ---
 
 rule_id: codeguard-0-api-web-services

--- a/skills/software-security/rules/codeguard-0-authentication-mfa.md
+++ b/skills/software-security/rules/codeguard-0-authentication-mfa.md
@@ -13,6 +13,9 @@ languages:
 - swift
 - typescript
 alwaysApply: false
+tags:
+- authentication
+- web
 ---
 
 rule_id: codeguard-0-authentication-mfa

--- a/skills/software-security/rules/codeguard-0-client-side-web-security.md
+++ b/skills/software-security/rules/codeguard-0-client-side-web-security.md
@@ -8,6 +8,8 @@ languages:
 - typescript
 - vlang
 alwaysApply: false
+tags:
+- web
 ---
 
 rule_id: codeguard-0-client-side-web-security

--- a/skills/software-security/rules/codeguard-0-cloud-orchestration-kubernetes.md
+++ b/skills/software-security/rules/codeguard-0-cloud-orchestration-kubernetes.md
@@ -4,6 +4,8 @@ languages:
 - javascript
 - yaml
 alwaysApply: false
+tags:
+- infrastructure
 ---
 
 rule_id: codeguard-0-cloud-orchestration-kubernetes

--- a/skills/software-security/rules/codeguard-0-data-storage.md
+++ b/skills/software-security/rules/codeguard-0-data-storage.md
@@ -6,6 +6,9 @@ languages:
 - sql
 - yaml
 alwaysApply: false
+tags:
+- data-security
+- infrastructure
 ---
 
 rule_id: codeguard-0-data-storage

--- a/skills/software-security/rules/codeguard-0-devops-ci-cd-containers.md
+++ b/skills/software-security/rules/codeguard-0-devops-ci-cd-containers.md
@@ -8,6 +8,8 @@ languages:
 - xml
 - yaml
 alwaysApply: false
+tags:
+- infrastructure
 ---
 
 rule_id: codeguard-0-devops-ci-cd-containers

--- a/skills/software-security/rules/codeguard-0-iac-security.md
+++ b/skills/software-security/rules/codeguard-0-iac-security.md
@@ -9,6 +9,8 @@ languages:
 - shell
 - yaml
 alwaysApply: false
+tags:
+- infrastructure
 ---
 
 rule_id: codeguard-0-iac-security

--- a/skills/software-security/rules/codeguard-0-input-validation-injection.md
+++ b/skills/software-security/rules/codeguard-0-input-validation-injection.md
@@ -15,6 +15,8 @@ languages:
 - sql
 - typescript
 alwaysApply: false
+tags:
+- web
 ---
 
 rule_id: codeguard-0-input-validation-injection

--- a/skills/software-security/rules/codeguard-0-logging.md
+++ b/skills/software-security/rules/codeguard-0-logging.md
@@ -5,6 +5,8 @@ languages:
 - javascript
 - yaml
 alwaysApply: false
+tags:
+- privacy
 ---
 
 rule_id: codeguard-0-logging

--- a/skills/software-security/rules/codeguard-0-privacy-data-protection.md
+++ b/skills/software-security/rules/codeguard-0-privacy-data-protection.md
@@ -5,6 +5,8 @@ languages:
 - matlab
 - yaml
 alwaysApply: false
+tags:
+- privacy
 ---
 
 rule_id: codeguard-0-privacy-data-protection

--- a/skills/software-security/rules/codeguard-0-session-management-and-cookies.md
+++ b/skills/software-security/rules/codeguard-0-session-management-and-cookies.md
@@ -11,6 +11,9 @@ languages:
 - ruby
 - typescript
 alwaysApply: false
+tags:
+- authentication
+- web
 ---
 
 rule_id: codeguard-0-session-management-and-cookies

--- a/skills/software-security/rules/codeguard-1-digital-certificates.md
+++ b/skills/software-security/rules/codeguard-1-digital-certificates.md
@@ -1,6 +1,8 @@
 ---
 description: Certificate Best Practices
 alwaysApply: true
+tags:
+- secrets
 ---
 
 rule_id: codeguard-1-digital-certificates

--- a/skills/software-security/rules/codeguard-1-hardcoded-credentials.md
+++ b/skills/software-security/rules/codeguard-1-hardcoded-credentials.md
@@ -1,6 +1,8 @@
 ---
 description: No Hardcoded Credentials
 alwaysApply: true
+tags:
+- secrets
 ---
 
 rule_id: codeguard-1-hardcoded-credentials

--- a/sources/rules/core/codeguard-SKILLS.md.template
+++ b/sources/rules/core/codeguard-SKILLS.md.template
@@ -24,10 +24,13 @@ When writing or reviewing code:
 - `codeguard-1-hardcoded-credentials.md` - Never hardcode secrets, passwords, API keys, or tokens
 - `codeguard-1-crypto-algorithms.md` - Use only modern, secure cryptographic algorithms
 - `codeguard-1-digital-certificates.md` - Validate and manage digital certificates securely
-2. Context-Specific Rules: Apply rules from /rules directory based on the language of the feature being implemented using the table given below:
+2. Tag-Based Rules: When you identify any of these security contexts in the code, apply ALL rules with the matching tag:
+<!-- TAG_MAPPINGS_START -->
+<!-- TAG_MAPPINGS_END -->
+3. Language-Specific Rules: Apply rules from /rules directory based on the programming language of the feature being implemented using the table given below:
 <!-- LANGUAGE_MAPPINGS_START -->
 <!-- LANGUAGE_MAPPINGS_END -->
-3. Proactive Security: Don't just avoid vulnerabilities-actively implement secure patterns:
+4. Proactive Security: Don't just avoid vulnerabilities-actively implement secure patterns:
 - Use parameterized queries for database access
 - Validate and sanitize all user input
 - Apply least-privilege principles
@@ -43,8 +46,8 @@ When generating or reviewing code, follow this workflow:
 ### 1. Initial Security Check
 Before writing any code:
 - Check: Will this handle credentials? → Apply codeguard-1-hardcoded-credentials
+- Check: What security tags apply? → Load all rules with matching tags (e.g., "authentication", "web", "secrets")
 - Check: What language am I using? → Identify applicable language-specific rules
-- Check: What security domains are involved? → Load relevant rule files
 
 ### 2. Code Generation
 While writing code:

--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -65,82 +65,35 @@ def matches_tag_filter(rule_tags: list[str], filter_tags: list[str]) -> bool:
     return all(tag in rule_tags for tag in filter_tags)
 
 
-def update_skill_md(language_to_rules: dict[str, list[str]], skill_path: Path) -> None:
-    """
-    Update SKILL.md with language-to-rules mapping table.
-
-    Args:
-        language_to_rules: Dictionary mapping languages to rule files
-        skill_path: Path to SKILL.md file
-    """
-    table_lines = [
-        "| Language | Rule Files to Apply |",
-        "|----------|---------------------|",
-    ]
-
-    for language in sorted(language_to_rules.keys()):
-        rules = sorted(language_to_rules[language])
-        rules_str = ", ".join(rules)
-        table_lines.append(f"| {language} | {rules_str} |")
-
+def _inject_mapping_table(
+    skill_path: Path,
+    mapping: dict[str, list[str]],
+    *,
+    key_header: str,
+    marker_name: str,
+) -> None:
+    """Replace ``<!-- {marker_name}_START/END -->`` in SKILL.md with a sorted
+    two-column markdown table built from ``mapping``. Missing markers raise."""
+    rules_col = "Rule Files to Apply"
+    sep = f"|{'-' * (len(key_header) + 2)}|{'-' * (len(rules_col) + 2)}|"
+    table_lines = [f"| {key_header} | {rules_col} |", sep]
+    for key in sorted(mapping):
+        table_lines.append(f"| {key} | {', '.join(sorted(mapping[key]))} |")
     table = "\n".join(table_lines)
 
-    start_marker = "<!-- LANGUAGE_MAPPINGS_START -->"
-    end_marker = "<!-- LANGUAGE_MAPPINGS_END -->"
-
+    start_marker = f"<!-- {marker_name}_START -->"
+    end_marker = f"<!-- {marker_name}_END -->"
     content = skill_path.read_text(encoding="utf-8")
-
     if start_marker not in content or end_marker not in content:
         raise RuntimeError(
-            f"Invalid SKILL.md: language mappings section markers not found in {skill_path}"
+            f"Invalid SKILL.md: {marker_name} section markers not found in {skill_path}"
         )
 
     start_idx = content.index(start_marker)
     end_idx = content.index(end_marker) + len(end_marker)
-    new_section = f"\n\n{table}\n\n"
-    updated_content = content[:start_idx] + new_section + content[end_idx:]
-
-    skill_path.write_text(updated_content, encoding="utf-8")
-    print(f"Updated SKILL.md with language mappings")
-
-
-def update_tag_mappings(tag_to_rules: dict[str, list[str]], skill_path: Path) -> None:
-    """
-    Update SKILL.md with tag-to-rules mapping table.
-
-    Args:
-        tag_to_rules: Dictionary mapping tags to rule files
-        skill_path: Path to SKILL.md file
-    """
-    table_lines = [
-        "| Security Context (Tag) | Rule Files to Apply |",
-        "|------------------------|---------------------|",
-    ]
-
-    for tag in sorted(tag_to_rules.keys()):
-        rules = sorted(tag_to_rules[tag])
-        rules_str = ", ".join(rules)
-        table_lines.append(f"| {tag} | {rules_str} |")
-
-    table = "\n".join(table_lines)
-
-    start_marker = "<!-- TAG_MAPPINGS_START -->"
-    end_marker = "<!-- TAG_MAPPINGS_END -->"
-
-    content = skill_path.read_text(encoding="utf-8")
-
-    if start_marker not in content or end_marker not in content:
-        # Markers are optional; skip silently so older templates still work.
-        print("Note: tag mappings markers not found in SKILL.md; skipping tag table")
-        return
-
-    start_idx = content.index(start_marker)
-    end_idx = content.index(end_marker) + len(end_marker)
-    new_section = f"\n\n{table}\n\n"
-    updated_content = content[:start_idx] + new_section + content[end_idx:]
-
-    skill_path.write_text(updated_content, encoding="utf-8")
-    print(f"Updated SKILL.md with tag mappings")
+    updated = content[:start_idx] + f"\n\n{table}\n\n" + content[end_idx:]
+    skill_path.write_text(updated, encoding="utf-8")
+    print(f"Updated SKILL.md with {marker_name} table")
 
 
 def convert_rules(
@@ -310,10 +263,18 @@ def convert_rules(
         )
         output_skill_path.write_text(template_content, encoding="utf-8")
 
-        update_skill_md(language_to_rules, output_skill_path)
-
-        if tag_to_rules:
-            update_tag_mappings(tag_to_rules, output_skill_path)
+        _inject_mapping_table(
+            output_skill_path,
+            language_to_rules,
+            key_header="Language",
+            marker_name="LANGUAGE_MAPPINGS",
+        )
+        _inject_mapping_table(
+            output_skill_path,
+            tag_to_rules,
+            key_header="Security Context (Tag)",
+            marker_name="TAG_MAPPINGS",
+        )
 
         for host_dir in SKILL_COPY_HOSTS:
             host_skill_dir = Path(output_dir) / host_dir / "skills" / "software-security"

--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -104,6 +104,45 @@ def update_skill_md(language_to_rules: dict[str, list[str]], skill_path: Path) -
     print(f"Updated SKILL.md with language mappings")
 
 
+def update_tag_mappings(tag_to_rules: dict[str, list[str]], skill_path: Path) -> None:
+    """
+    Update SKILL.md with tag-to-rules mapping table.
+
+    Args:
+        tag_to_rules: Dictionary mapping tags to rule files
+        skill_path: Path to SKILL.md file
+    """
+    table_lines = [
+        "| Security Context (Tag) | Rule Files to Apply |",
+        "|------------------------|---------------------|",
+    ]
+
+    for tag in sorted(tag_to_rules.keys()):
+        rules = sorted(tag_to_rules[tag])
+        rules_str = ", ".join(rules)
+        table_lines.append(f"| {tag} | {rules_str} |")
+
+    table = "\n".join(table_lines)
+
+    start_marker = "<!-- TAG_MAPPINGS_START -->"
+    end_marker = "<!-- TAG_MAPPINGS_END -->"
+
+    content = skill_path.read_text(encoding="utf-8")
+
+    if start_marker not in content or end_marker not in content:
+        # Markers are optional; skip silently so older templates still work.
+        print("Note: tag mappings markers not found in SKILL.md; skipping tag table")
+        return
+
+    start_idx = content.index(start_marker)
+    end_idx = content.index(end_marker) + len(end_marker)
+    new_section = f"\n\n{table}\n\n"
+    updated_content = content[:start_idx] + new_section + content[end_idx:]
+
+    skill_path.write_text(updated_content, encoding="utf-8")
+    print(f"Updated SKILL.md with tag mappings")
+
+
 def convert_rules(
     input_path: str,
     output_dir: str = "dist",
@@ -182,6 +221,7 @@ def convert_rules(
 
     results = {"success": [], "errors": [], "skipped": []}
     language_to_rules = defaultdict(list)
+    tag_to_rules = defaultdict(list)
 
     # Process each file
     for md_file in md_files:
@@ -219,6 +259,9 @@ def convert_rules(
 
             for language in result.languages:
                 language_to_rules[language].append(result.filename)
+
+            for tag in result.tags:
+                tag_to_rules[tag].append(result.filename)
 
         except FileNotFoundError as e:
             error_msg = f"{md_file.name}: File not found - {e}"
@@ -268,6 +311,9 @@ def convert_rules(
         output_skill_path.write_text(template_content, encoding="utf-8")
 
         update_skill_md(language_to_rules, output_skill_path)
+
+        if tag_to_rules:
+            update_tag_mappings(tag_to_rules, output_skill_path)
 
         for host_dir in SKILL_COPY_HOSTS:
             host_skill_dir = Path(output_dir) / host_dir / "skills" / "software-security"

--- a/src/formats/agentskills.py
+++ b/src/formats/agentskills.py
@@ -41,9 +41,9 @@ class AgentSkillsFormat(BaseFormat):
         """
         Generate Agent Skills .md format.
 
-        Agent Skills should preserve the original YAML frontmatter
-        (description, languages, alwaysApply) so the rules remain complete
-        and can be referenced properly by AI coding agents.
+        Agent Skills preserves the original YAML frontmatter (description,
+        languages, alwaysApply, tags) so the rules remain complete and can
+        be referenced properly by AI coding agents.
 
         Args:
             rule: The processed rule to format
@@ -69,5 +69,11 @@ class AgentSkillsFormat(BaseFormat):
 
         # Add alwaysApply
         yaml_lines.append(f"alwaysApply: {str(rule.always_apply).lower()}")
+
+        # Add tags as expanded YAML list (preserves the source format)
+        if rule.tags:
+            yaml_lines.append("tags:")
+            for tag in rule.tags:
+                yaml_lines.append(f"- {tag}")
 
         return self._build_yaml_frontmatter(yaml_lines, rule.content)

--- a/src/formats/antigravity.py
+++ b/src/formats/antigravity.py
@@ -16,6 +16,7 @@ class AntigravityFormat(BaseFormat):
     - globs: (if trigger is 'glob') File matching patterns
     - description: Rule description
     - version: Rule version
+    - tags: (optional) List of categorization tags
 
     Rules use activation types (Always On or Glob) to determine when
     they apply, similar to Windsurf's implementation.
@@ -69,5 +70,9 @@ class AntigravityFormat(BaseFormat):
 
         # Add version
         yaml_lines.append(f"version: {self.version}")
+
+        if rule.tags:
+            tags_str = ", ".join(rule.tags)
+            yaml_lines.append(f"tags: [{tags_str}]")
 
         return self._build_yaml_frontmatter(yaml_lines, rule.content)

--- a/src/formats/copilot.py
+++ b/src/formats/copilot.py
@@ -13,8 +13,9 @@ class CopilotFormat(BaseFormat):
 
     Copilot uses .instructions.md files with YAML frontmatter containing:
     - applyTo: File matching patterns
-    - title: Rule title/description
+    - description: Rule description
     - version: Rule version
+    - tags: (optional) List of categorization tags
     """
 
     def get_format_name(self) -> str:
@@ -52,5 +53,9 @@ class CopilotFormat(BaseFormat):
 
         # Add version
         yaml_lines.append(f"version: {self.version}")
+
+        if rule.tags:
+            tags_str = ", ".join(rule.tags)
+            yaml_lines.append(f"tags: [{tags_str}]")
 
         return self._build_yaml_frontmatter(yaml_lines, rule.content)

--- a/src/formats/cursor.py
+++ b/src/formats/cursor.py
@@ -16,6 +16,7 @@ class CursorFormat(BaseFormat):
     - globs: File matching patterns
     - version: Rule version
     - alwaysApply: (optional) Whether to apply to all files
+    - tags: (optional) List of categorization tags
     """
 
     def get_format_name(self) -> str:
@@ -55,5 +56,9 @@ class CursorFormat(BaseFormat):
         # Add alwaysApply if needed
         if rule.always_apply:
             yaml_lines.append("alwaysApply: true")
+
+        if rule.tags:
+            tags_str = ", ".join(rule.tags)
+            yaml_lines.append(f"tags: [{tags_str}]")
 
         return self._build_yaml_frontmatter(yaml_lines, rule.content)

--- a/src/formats/windsurf.py
+++ b/src/formats/windsurf.py
@@ -16,6 +16,7 @@ class WindsurfFormat(BaseFormat):
     - globs: (if trigger is 'glob') File matching patterns
     - title: Rule title/description
     - version: Rule version
+    - tags: (optional) List of categorization tags
     """
 
     def get_format_name(self) -> str:
@@ -57,5 +58,9 @@ class WindsurfFormat(BaseFormat):
 
         # Add version
         yaml_lines.append(f"version: {self.version}")
+
+        if rule.tags:
+            tags_str = ", ".join(rule.tags)
+            yaml_lines.append(f"tags: [{tags_str}]")
 
         return self._build_yaml_frontmatter(yaml_lines, rule.content)


### PR DESCRIPTION
## Summary

This PR introduces tag-based rule mapping functionality to improve AI model adherence when applying security rules. The core enhancement provides explicit contextual guidance through tags, addressing challenges observed when models attempt to determine which rules to apply.

### Problem Statement

Previous approaches faced several limitations:

- **System prompts alone were insufficient**: Models could not reliably determine which rules to apply based solely on initial instructions
- **Language-only filtering was too restrictive**: Relying only on programming language to filter rules missed cross-cutting security concerns
- **Extension bias in AI models**: Models showed bias toward file extensions they considered more "dangerous" (e.g., `.php`, `.py`), causing them to overlook rules targeting extensions like `.html` or `.css`
- **Tags existed but were invisible to agents**: cosai already validates and stores tags from rule frontmatter (`utils.validate_tags`, `ProcessedRule.tags`, `ConversionResult.tags`), but the data was never propagated to any IDE-format output or surfaced in `SKILL.md` — so agents had no way to use them

### Background: what tags were originally built for

Tag support was introduced upstream in cosai PR #70 (`feature/add-tags-filtering`). The *only* consumer that PR shipped was a build-time CLI filter (`--tag`) used to slice the output bundle by tag — documented in `docs/custom-rules.md`:

```bash
# Build only rules tagged with data-security
uv run python src/convert_to_ide_formats.py --tag data-security

# AND logic across multiple tags
uv run python src/convert_to_ide_formats.py --tag api,web-security
```

That filter is useful for maintainers producing custom bundles, but it runs at build time and never reaches the agent. The tag values are read by `matches_tag_filter()` in `convert_to_ide_formats.py` to decide whether to *include* a rule in the output, and then discarded — they don't appear in any generated `.mdc`, `.instructions.md`, `.md`, or `SKILL.md` file.

This PR adds the missing second consumer: rather than just filtering the build, tags are now surfaced into every IDE output and aggregated into a lookup table in `SKILL.md`, so an AI coding agent can use the same tag taxonomy at runtime. The existing `--tag` CLI filter is left untouched and remains complementary.

### Solution

Tag-based rule mapping unlocks the tag data that already exists:

1. **Tags propagated to agent-facing files**: rule frontmatter tags (which already exist in `sources/rules/core/*.md` today) now also appear in the generated IDE outputs and the published `skills/software-security/` bundle, so agents reading those files at runtime can see them — not just the build script at conversion time
2. **Cross-language rule grouping**: Tags enable grouping rules across various languages and extensions, overcoming the file-extension bias
3. **Dynamic tag-to-rules mapping**: The `SKILL.md` template now includes a generated table mapping tags to their associated rules, giving agents an explicit lookup mechanism
4. **Tags surfaced in every IDE output**: Cursor, Copilot, Windsurf, Antigravity, and all Agent Skills–based formats now include `tags:` in the generated frontmatter

## Changes

### Core Changes

- **`src/convert_to_ide_formats.py`**:
  - Added `update_tag_mappings()` to generate the tag-to-rules mapping table in `SKILL.md`
  - Tags collected per run via a new `tag_to_rules` dictionary
  - Tags are now propagated to all IDE format outputs
- **`sources/rules/core/codeguard-SKILLS.md.template`**:
  - Inserted a new **Tag-Based Rules** section (with `<!-- TAG_MAPPINGS_START -->` / `<!-- TAG_MAPPINGS_END -->` markers for dynamic injection) immediately before the existing **Language-Specific Rules** section, and renumbered the trailing **Proactive Security** section accordingly
  - Replaced the generic "What security domains are involved? → Load relevant rule files" item in the Initial Security Check with a tag-specific check: "What security tags apply? → Load all rules with matching tags (e.g., 'authentication', 'web', 'secrets')"
- **`skills/software-security/**`**: Regenerated artifacts (committed because they ship as the plugin payload) — 15 rule files updated to include `tags:` in their frontmatter, `SKILL.md` updated with the new tag mappings table

### IDE Format Updates

- **Cursor** (`src/formats/cursor.py`): Tags added to YAML frontmatter as `tags: [a, b]`
- **Copilot** (`src/formats/copilot.py`): Tags added to YAML frontmatter as `tags: [a, b]`
- **Windsurf** (`src/formats/windsurf.py`): Tags added to YAML frontmatter as `tags: [a, b]`
- **Antigravity** (`src/formats/antigravity.py`): Tags added to YAML frontmatter as `tags: [a, b]`
- **Agent Skills** (`src/formats/agentskills.py`): Tags added as expanded YAML list — inherited automatically by OpenCode, Codex, OpenClaw, Hermes, and Claude formats

### Intentionally NOT in this PR

- **No changes to `src/tag_mappings.py`** → avoids overlap/conflict with the open upstream PR #80, which is expanding `KNOWN_TAGS` independently
- **No interactive "auto-add unknown tag" helper** → `validate_unified_rules.py` already errors on unknown tags, and auto-adding tags via regex would bypass code review

## Usage

Tags are already declared in rule frontmatter today (e.g. `codeguard-1-hardcoded-credentials.md` has `tags: [secrets]`). With this PR they flow through to every output:

```yaml
# Input rule (unchanged)
---
description: Authentication and MFA best practices
languages: [c, go, java, javascript, python]
tags:
  - authentication
  - web
alwaysApply: false
---
```

```yaml
# Generated Cursor output (.cursor/rules/...mdc)
---
description: Authentication and MFA best practices
globs: **/*.c,**/*.go,**/*.java,...
version: 1.3.1
tags: [authentication, web]
---
```

```markdown
# Generated section in skills/software-security/SKILL.md
| Security Context (Tag) | Rule Files to Apply |
|------------------------|---------------------|
| authentication | codeguard-0-authentication-mfa.md, codeguard-0-session-management-and-cookies.md |
| secrets        | codeguard-0-additional-cryptography.md, codeguard-1-digital-certificates.md, codeguard-1-hardcoded-credentials.md |
| web            | codeguard-0-api-web-services.md, codeguard-0-authentication-mfa.md, codeguard-0-client-side-web-security.md, ... |
```

## Test Plan

- [x] Run conversion script with rules containing various tags
- [x] Verify tags appear in generated IDE-specific rule files (Cursor, Copilot, Windsurf, Antigravity, Agent Skills, OpenCode, Codex, OpenClaw, Hermes, Claude)
- [x] Verify `SKILL.md` contains updated tag-to-rules mapping table
- [x] Verify `validate_unified_rules.py` still passes on all 23 rules
- [x] Verify falls back silently when older templates lack the new markers
- [x] Verify the existing `--tag` CLI filter still works unchanged (complementary, not replaced)

