### PR TITLE
Add --update-cache option for Claude Code plugin development

### DIFF
--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -65,6 +65,81 @@ def matches_tag_filter(rule_tags: list[str], filter_tags: list[str]) -> bool:
     return all(tag in rule_tags for tag in filter_tags)
 
 
+def update_claude_cache(version: str) -> bool:
+    """Refresh the local Claude Code plugin cache with generated rules.
+
+    Copies ``skills/software-security/`` into Claude Code's cache directory
+    so locally modified or custom rules can be tested without waiting for a
+    marketplace release.
+
+    Cache path mirrors the marketplace layout:
+      ``~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/software-security``
+
+    Args:
+        version: Version string from pyproject.toml (e.g., "1.3.1")
+
+    Returns:
+        True on success, False on any failure (logs an error message).
+    """
+    # Marketplace and plugin names are pinned to the local manifest so the
+    # path stays in sync if the marketplace structure ever changes.
+    marketplace_name = "project-codeguard"
+    plugin_name = "codeguard-security"
+
+    # Validate the version string against an allow-list before splicing it
+    # into a filesystem path (defense-in-depth against path traversal).
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", version):
+        print(f"❌ Refusing to update cache: invalid version format '{version}'")
+        return False
+
+    source_dir = PROJECT_ROOT / "skills" / "software-security"
+    if not source_dir.exists():
+        print(f"❌ Source directory not found: {source_dir}")
+        return False
+
+    cache_base = (
+        Path.home()
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / marketplace_name
+        / plugin_name
+        / version
+    )
+    cache_dir = cache_base / "skills" / "software-security"
+
+    try:
+        if cache_base.exists():
+            shutil.rmtree(cache_base)
+            print(f"🗑️  Cleared existing cache: {cache_base}")
+    except OSError as exc:
+        print(f"❌ Failed to clear existing cache: {exc}")
+        return False
+
+    try:
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source_dir, cache_dir)
+    except (OSError, shutil.Error) as exc:
+        print(f"❌ Failed to copy to cache: {exc}")
+        return False
+
+    rules_dir = cache_dir / "rules"
+    if not rules_dir.exists():
+        print("⚠️  Warning: rules directory missing after copy")
+        return False
+
+    rule_count = sum(1 for _ in rules_dir.glob("*.md"))
+    if rule_count == 0:
+        print("⚠️  Warning: no rules found in cache after copy")
+        return False
+
+    print(f"✅ Updated cache: {cache_dir}")
+    print(f"   → {rule_count} rules copied")
+    if (cache_dir / "SKILL.md").exists():
+        print("   → SKILL.md copied")
+    return True
+
+
 def update_skill_md(language_to_rules: dict[str, list[str]], skill_path: Path) -> None:
     """
     Update SKILL.md with language-to-rules mapping table.
@@ -326,6 +401,16 @@ if __name__ == "__main__":
         dest="tags",
         help="Filter rules by tags (comma-separated, case-insensitive, AND logic). Example: --tag api,web-security",
     )
+    parser.add_argument(
+        "--update-cache",
+        action="store_true",
+        help=(
+            "After a successful build, refresh the local Claude Code plugin "
+            "cache (~/.claude/plugins/cache/project-codeguard/codeguard-security/"
+            "<version>/skills/software-security) so modified rules are picked "
+            "up immediately without waiting for a marketplace release."
+        ),
+    )
 
     cli_args = parser.parse_args()
     try:
@@ -445,3 +530,12 @@ if __name__ == "__main__":
     sync_plugin_metadata(version)
 
     print("✅ All conversions successful")
+
+    # Optional developer convenience: refresh the local Claude Code plugin
+    # cache so the just-built rules can be exercised in Claude Code without
+    # waiting for a marketplace release. Off by default.
+    if cli_args.update_cache:
+        print("\nUpdating Claude Code plugin cache...")
+        if not update_claude_cache(version):
+            print("❌ Failed to update cache")
+            sys.exit(1)


### PR DESCRIPTION
## Summary

This PR adds a `--update-cache` CLI option to the conversion script (`src/convert_to_ide_formats.py`) to streamline custom rule development for Claude Code environments. The flag is purely additive — it extends the existing converter; no other entry point or script is introduced.

### Problem

When developing or customizing CodeGuard rules for Claude Code, users face workflow friction:

- **Rules are generated to `skills/software-security/`** — The conversion script outputs Claude Code rules to the project's `skills/` directory
- **Claude Code reads from its plugin cache** — The agent reads rules from `~/.claude/plugins/cache/project-codeguard/codeguard-security/{version}/skills/software-security/`
- **Manual sync required** — Users must manually copy files to the cache directory for changes to take effect
- **Version-specific paths** — The cache path includes the version number, making manual updates error-prone

### Solution

Extend the conversion script (`src/convert_to_ide_formats.py`) with an opt-in `--update-cache` flag that automatically syncs the just-generated rules to Claude Code's local plugin cache directory at the end of a successful conversion run. Off by default — no impact on standard CI builds or contributor workflow when the flag is not passed.

## Changes

All changes are scoped to `src/convert_to_ide_formats.py` (the existing conversion script). No new scripts, modules, or dependencies are introduced.

- Add `update_claude_cache(version)` function to `src/convert_to_ide_formats.py` to sync rules to the Claude Code plugin cache
- Add `--update-cache` CLI flag to the same script's argparse setup, triggering the sync after a successful conversion
- Cache path is version-aware: the version is read from `pyproject.toml` via the existing `get_version_from_pyproject()` helper and passed through to `update_claude_cache()`
- Marketplace name (`project-codeguard`) and plugin name (`codeguard-security`) are pinned in the function to match `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`
- Validate version against `[A-Za-z0-9._-]+` allow-list before splicing into a filesystem path (defense-in-depth against path traversal)
- Fully replace the existing version directory (`rmtree` of `cache_base`, then `copytree`) so stale rules from a previous build can't linger. Note: this is *not* atomic — there is a brief window where the cache directory is missing or partially written; the flag is intended for dev use where this is acceptable
- Wrap all `shutil` operations in `try/except`; failures exit non-zero with a clear message
- Verify rules and `SKILL.md` were actually copied before returning success

No new dependencies; only stdlib (`re`, `shutil`, `pathlib`).

## Usage

```bash
# Convert core rules and update Claude Code cache
python src/convert_to_ide_formats.py --update-cache

# Combine with tag filter (cache will then contain only the filtered subset)
python src/convert_to_ide_formats.py --tag authentication --update-cache

# Convert multiple source directories and update cache
python src/convert_to_ide_formats.py --source core custom --update-cache
```

**Note:** The `--source` flag accepts multiple directories under `sources/rules/`. In the last example, `custom` refers to a hypothetical `sources/rules/custom/` directory — this does not exist by default in the repository. Users can create their own source directories (e.g., `sources/rules/internal/`) to organize organization-specific rules alongside the core rules.

## Use Cases

- Developing custom rules for internal/organization use
- Testing rule modifications before contributing upstream
- Rapid iteration on rule content without manual file copying
- Debugging skill behavior after changes to `agentskills.py` or the `SKILL.md` template

## Test Plan

- [x] Run conversion with `--update-cache` flag
- [x] Verify rules are copied to `~/.claude/plugins/cache/project-codeguard/codeguard-security/{version}/skills/software-security/` (tested with isolated `$HOME`: 23 rules + `SKILL.md` copied)
- [x] Test with invalid version format to verify validation rejects before any FS write
- [x] Verify the version cache directory is cleared and rewritten on each run (no stale files linger)
- [x] Verify standard build is unaffected when flag is omitted
- [x] Verify `--help` documents the new flag clearly

