### PR TITLE
Align Claude Code plugin docs

### DIFF
--- a/docs/claude-code-skill-plugin.md
+++ b/docs/claude-code-skill-plugin.md
@@ -14,25 +14,31 @@ Agent Skills are model-invoked capabilities that Claude autonomously uses based 
 
 ### Prerequisites
 
-- Claude Code installed
+- Claude Code installed with `/plugin` support
 - Basic familiarity with Claude Code's plugin system
+
+!!! warning "Trust note"
+    Claude Code plugins can provide skills, agents, hooks, MCP servers, and executable components. Only install marketplaces and plugins from sources you trust.
 
 ### Installation Steps
 
 1. **Add the Project CodeGuard marketplace:**
-   ```bash
+   ```text
    /plugin marketplace add cosai-oasis/project-codeguard
    ```
 
 2. **Install the security plugin:**
-   ```bash
+   ```text
    /plugin install codeguard-security@project-codeguard
    ```
 
-3. **Restart Claude Code** (if prompted)
+3. **Reload plugins:**
+   ```text
+   /reload-plugins
+   ```
 
 4. **Verify installation:**
-   The skill is automatically loaded. Start coding and Claude will apply security rules automatically.
+   Open `/plugin` and check the **Installed** tab. `codeguard-security@project-codeguard` should be listed and enabled.
 
 ## How It Works
 
@@ -130,25 +136,30 @@ const upload = multer({
 
 ## Team Deployment
 
-For organizations, deploy CodeGuard to all developers automatically:
+For teams, make CodeGuard available through repository settings:
 
 1. Add to your project's `.claude/settings.json`:
    ```json
    {
-     "marketplaces": [{"source": "cosai-oasis/project-codeguard"}],
-     "plugins": [
-       {
-         "name": "codeguard-security",
-         "marketplace": "project-codeguard",
-         "enabled": true
+     "extraKnownMarketplaces": {
+       "project-codeguard": {
+         "source": {
+           "source": "github",
+           "repo": "cosai-oasis/project-codeguard"
+         }
        }
-     ]
+     },
+     "enabledPlugins": {
+       "codeguard-security@project-codeguard": true
+     }
    }
    ```
 
 2. Team members trust the repository folder
 
-3. CodeGuard installs automatically for everyone
+3. Claude Code prompts team members to install and enable CodeGuard
+
+For managed environments, administrators can restrict allowed marketplaces with `strictKnownMarketplaces`.
 
 ## All Security Rules
 
@@ -187,11 +198,21 @@ These rules apply based on the programming language, framework, or feature being
 
 ## Updating
 
-To update to the latest security rules:
+To refresh the CodeGuard marketplace listing:
+
+```text
+/plugin marketplace update project-codeguard
+```
+
+To update the installed plugin from a shell:
 
 ```bash
-/plugin update codeguard-security@project-codeguard
+claude plugin update codeguard-security@project-codeguard
 ```
+
+Restart Claude Code after updating. If an open session prompts you to reload plugin changes, run `/reload-plugins`.
+
+You can also run `/plugin`, open the **Marketplaces** tab, select `project-codeguard`, and enable auto-update.
 
 ## Customization
 
@@ -199,15 +220,17 @@ To update to the latest security rules:
 
 If needed, temporarily disable:
 
-```bash
+```text
 /plugin disable codeguard-security@project-codeguard
 ```
 
 Re-enable:
 
-```bash
+```text
 /plugin enable codeguard-security@project-codeguard
 ```
+
+Run `/reload-plugins` after changing plugin state.
 
 ### Using Specific Rule Files
 
@@ -235,9 +258,9 @@ Use the relevant CodeGuard rules for each check.
 
 ### Plugin Not Loading
 
-1. Verify installation: `/plugin` → "Manage Plugins"
-2. Check that `codeguard-security` is listed and enabled
-3. Restart Claude Code
+1. Verify installation: `/plugin` → **Installed**
+2. Check that `codeguard-security@project-codeguard` is listed and enabled
+3. Run `/reload-plugins`
 
 ### Rules Not Being Applied
 
@@ -247,11 +270,7 @@ Use the relevant CodeGuard rules for each check.
 
 ### Checking Plugin Version
 
-```bash
-/plugin list
-```
-
-Look for `codeguard-security@project-codeguard` and note the version number.
+Open `/plugin` and check the **Installed** tab. Look for `codeguard-security@project-codeguard` and note the version number.
 
 ## Best Practices
 
@@ -293,7 +312,18 @@ This command:
 - Generates `skills/` directory with the 23 core security rules (Claude Code plugin)
 - Creates `dist/` with all supported agent-specific formats
 
-**Note:** The Claude Code plugin (`skills/`) always contains only the 23 curated core rules. To build bundles with OWASP supplementary rules for other IDEs, use `--source core owasp`, but this only affects `dist/`, not `skills/`.
+**Note:** The Claude Code plugin (`skills/`) uses the curated core rules. To build bundles with OWASP supplementary rules for other IDEs, use `--source core owasp`, but this only affects `dist/`, not `skills/`.
+
+### Local Development
+
+To test the plugin from a local checkout without installing it:
+
+```bash
+uv run python src/convert_to_ide_formats.py
+claude --plugin-dir .
+```
+
+`--plugin-dir` loads the local plugin for that Claude Code session. If the session is already running and you regenerate files, run `/reload-plugins`.
 
 ## Advanced Usage
 
@@ -398,21 +428,6 @@ Found an issue with the plugin or want to improve it?
 2. **Suggest rules**: [GitHub Discussions](https://github.com/cosai-oasis/project-codeguard/discussions)
 3. **Contribute**: [Contributing Guide](https://github.com/cosai-oasis/project-codeguard/blob/main/CONTRIBUTING.md)
 
-## Version History
-
-### Version 1.0.1
-- Changed `codeguard-1-safe-c-functions` from always-apply to `codeguard-0-safe-c-functions` context-specific rule (C/C++ only)
-- Updated rule counts: 3 always-apply rules, 19 context-specific rules
-- Fixed GitHub Copilot instructions to use `description` field instead of `title`
-
-### Version 1.0.0
-- Initial release
-- 22 comprehensive security rules
-- 4 always-apply rules
-- 18 context-specific rules
-- Support for all major programming languages
-- Complete technology stack coverage
-
 ## Resources
 
 - **Project Website**: [https://project-codeguard.org](https://project-codeguard.org)
@@ -432,5 +447,3 @@ Need help? We're here for you:
 1. **Documentation**: Start with [Getting Started Guide](https://project-codeguard.org/getting-started/)
 2. **Community**: Join [GitHub Discussions](https://github.com/cosai-oasis/project-codeguard/discussions)
 3. **Issues**: Report bugs via [GitHub Issues](https://github.com/cosai-oasis/project-codeguard/issues)
-
-

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -96,12 +96,13 @@ Once hidden files are visible, copy the appropriate directory to your project ro
 
 **A:** Yes! Install the Project CodeGuard Claude Code plugin (Agent Skill) and Claude will apply the security rules automatically while you code.
 
-```bash
+```text
 /plugin marketplace add cosai-oasis/project-codeguard
 /plugin install codeguard-security@project-codeguard
+/reload-plugins
 ```
 
-For team/repo defaults, add the plugin in `.claude/settings.json` so it’s enabled for all contributors. See the [Claude Code Plugin documentation](claude-code-skill-plugin.md) for details and troubleshooting.
+For team/repo defaults, add the plugin in `.claude/settings.json` so contributors who trust the repository are prompted to install and enable it. See the [Claude Code Plugin documentation](claude-code-skill-plugin.md) for the current settings schema, updates, and troubleshooting.
 
 
 ## Q: How can I report a problem or enhancement to any of the rules?
@@ -141,6 +142,3 @@ See [CONTRIBUTING.md](https://github.com/cosai-oasis/project-codeguard/blob/main
 
 - [Open an issue](https://github.com/cosai-oasis/project-codeguard/issues) with your question
 - [Start a discussion](https://github.com/cosai-oasis/project-codeguard/discussions) to chat with the community
-
-
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -183,17 +183,25 @@ Select your AI coding tool and follow the instructions:
 
     1. **Add** the Project CodeGuard marketplace:
 
-        ```bash
+        ```text
         /plugin marketplace add cosai-oasis/project-codeguard
         ```
 
     2. **Install** the security plugin:
 
-        ```bash
+        ```text
         /plugin install codeguard-security@project-codeguard
         ```
 
-    The plugin automatically loads and applies security rules. See the [Claude Code Plugin documentation](claude-code-skill-plugin.md) for details.
+    3. **Reload plugins** so Claude Code picks up the new skill:
+
+        ```text
+        /reload-plugins
+        ```
+
+    4. **Verify** the plugin is enabled from `/plugin` → **Installed**.
+
+    See the [Claude Code Plugin documentation](claude-code-skill-plugin.md) for team setup, updates, and troubleshooting.
 
 === "Codex"
 

--- a/docs/install-paths.md
+++ b/docs/install-paths.md
@@ -220,20 +220,23 @@ An administrator configures the rules once in the vendor's team/org settings; th
         |:---|:---|
         | macOS | `/Library/Application Support/ClaudeCode/managed-settings.json` |
         | Linux / WSL | `/etc/claude-code/managed-settings.json` |
-        | Windows | `C:\ProgramData\ClaudeCode\managed-settings.json` |
+        | Windows | `C:\Program Files\ClaudeCode\managed-settings.json` |
 
     2. Add the CodeGuard marketplace and plugin:
 
         ```json
         {
-          "marketplaces": [{ "source": "cosai-oasis/project-codeguard" }],
-          "plugins": [
-            {
-              "name": "codeguard-security",
-              "marketplace": "project-codeguard",
-              "enabled": true
+          "extraKnownMarketplaces": {
+            "project-codeguard": {
+              "source": {
+                "source": "github",
+                "repo": "cosai-oasis/project-codeguard"
+              }
             }
-          ]
+          },
+          "enabledPlugins": {
+            "codeguard-security@project-codeguard": true
+          }
         }
         ```
 
@@ -245,7 +248,7 @@ An administrator configures the rules once in the vendor's team/org settings; th
     - Managed settings take precedence over `~/.claude/settings.json` and `<repo>/.claude/settings.json`; users cannot disable the plugin locally.
     - Updates to the CodeGuard plugin itself flow from the marketplace — you only redeploy `managed-settings.json` if you change which plugins are enforced.
 
-    :material-book-open-page-variant: [Claude Code settings documentation](https://docs.claude.com/en/docs/claude-code/settings) · [Plugin guide](claude-code-skill-plugin.md)
+    :material-book-open-page-variant: [Claude Code settings documentation](https://code.claude.com/docs/en/settings) · [Plugin guide](claude-code-skill-plugin.md)
 
 !!! note "Tools without an org-admin layer"
     Not every tool offers centrally pushed rules. For these, use **project-scope** install (commit rules to each repo) or a shared template repository as your enforcement mechanism:


### PR DESCRIPTION
## Summary
- Align Claude Code plugin install, reload, update, and verification docs with current Claude Code behavior.
- Update managed settings examples to use the current marketplace/plugin schema.
- Add a concise local development note for testing with `claude --plugin-dir .`.

## Validation
- `uv run mkdocs build --strict`

Closes #63
Closes #74