### PR TITLE
Rename release assets to CodeGuard bundles

### DIFF
--- a/.github/workflows/build-ide-bundles.yml
+++ b/.github/workflows/build-ide-bundles.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Get version from release
         id: get_version
@@ -52,37 +52,31 @@ jobs:
         run: uv run python src/convert_to_ide_formats.py
 
       - name: Create release archives
+        shell: bash
         run: |
           cd dist
-          zip -r ../ide-rules-claude.zip .claude/
-          zip -r ../ide-rules-cursor.zip .cursor/
-          zip -r ../ide-rules-windsurf.zip .windsurf/
-          zip -r ../ide-rules-copilot.zip .github/
+          zip -r ../codeguard-claude.zip .claude/
+          zip -r ../codeguard-cursor.zip .cursor/
+          zip -r ../codeguard-windsurf.zip .windsurf/
+          zip -r ../codeguard-copilot.zip .github/
           # Antigravity + Codex share .agents/; scope each zip to its own subpath.
-          zip -r ../ide-rules-antigravity.zip .agents/rules/
-          zip -r ../ide-rules-opencode.zip .opencode/
-          zip -r ../ide-rules-codex.zip .agents/skills/
-          zip -r ../ide-rules-openclaw.zip .openclaw/
-          zip -r ../ide-rules-hermes.zip .hermes/
+          zip -r ../codeguard-antigravity.zip .agents/rules/
+          zip -r ../codeguard-opencode.zip .opencode/
+          zip -r ../codeguard-codex.zip .agents/skills/
+          zip -r ../codeguard-openclaw.zip .openclaw/
+          zip -r ../codeguard-hermes.zip .hermes/
           cd ..
-          zip -r ide-rules-all.zip dist/
-          ls -lh ide-rules-*.zip
+          zip -r codeguard-all.zip dist/
+
+          sha256sum codeguard-*.zip > SHA256SUMS
+          sha256sum --check SHA256SUMS
+
+          ls -lh codeguard-*.zip SHA256SUMS
 
       - name: Upload release assets
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.get_version.outputs.tag }}
         run: |
-          gh release upload "$TAG" \
-            ide-rules-all.zip \
-            ide-rules-claude.zip \
-            ide-rules-cursor.zip \
-            ide-rules-windsurf.zip \
-            ide-rules-copilot.zip \
-            ide-rules-antigravity.zip \
-            ide-rules-opencode.zip \
-            ide-rules-codex.zip \
-            ide-rules-openclaw.zip \
-            ide-rules-hermes.zip \
-            --clobber
-
+          gh release upload "$TAG" codeguard-*.zip SHA256SUMS

--- a/.github/workflows/update-codeguard-rules.yml
+++ b/.github/workflows/update-codeguard-rules.yml
@@ -35,12 +35,14 @@ jobs:
 
           # Format configurations: directory -> zip asset name.
           declare -A FORMATS=(
-            [".cursor/rules"]="ide-rules-cursor.zip"
-            [".windsurf/rules"]="ide-rules-windsurf.zip"
-            [".github/instructions"]="ide-rules-copilot.zip"
-            [".agents/rules"]="ide-rules-antigravity.zip"
-            [".opencode/skills/codeguard/rules"]="ide-rules-opencode.zip"
-            [".agents/skills/codeguard/rules"]="ide-rules-codex.zip"
+            [".cursor/rules"]="codeguard-cursor.zip"
+            [".windsurf/rules"]="codeguard-windsurf.zip"
+            [".github/instructions"]="codeguard-copilot.zip"
+            [".agents/rules"]="codeguard-antigravity.zip"
+            [".opencode/skills/codeguard/rules"]="codeguard-opencode.zip"
+            [".agents/skills/codeguard/rules"]="codeguard-codex.zip"
+            [".openclaw/skills/codeguard/rules"]="codeguard-openclaw.zip"
+            [".hermes/skills/codeguard/rules"]="codeguard-hermes.zip"
           )
 
           # File patterns for each format
@@ -51,6 +53,8 @@ jobs:
             [".agents/rules"]="codeguard-*.md"
             [".opencode/skills/codeguard/rules"]="codeguard-*.md"
             [".agents/skills/codeguard/rules"]="codeguard-*.md"
+            [".openclaw/skills/codeguard/rules"]="codeguard-*.md"
+            [".hermes/skills/codeguard/rules"]="codeguard-*.md"
           )
 
           # Legacy paths: warn so users migrate instead of silently going stale.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ Select your AI coding tool and follow the instructions:
 
 === "Cursor"
 
-    1. **Download** [`ide-rules-cursor.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-cursor.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.cursor/` directory to your project root:
 
@@ -79,7 +79,7 @@ Select your AI coding tool and follow the instructions:
 
 === "Windsurf"
 
-    1. **Download** [`ide-rules-windsurf.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-windsurf.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.windsurf/` directory to your project root:
 
@@ -91,7 +91,7 @@ Select your AI coding tool and follow the instructions:
 
 === "GitHub Copilot"
 
-    1. **Download** [`ide-rules-copilot.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-copilot.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.github/` directory to your project root:
 
@@ -103,7 +103,7 @@ Select your AI coding tool and follow the instructions:
 
 === "Antigravity"
 
-    1. **Download** [`ide-rules-antigravity.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-antigravity.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.agents/` directory to your project root:
 
@@ -125,7 +125,7 @@ Select your AI coding tool and follow the instructions:
 
     Using skills is more context-efficient as only relevant rules are loaded per session based on the files you're working with.
 
-    1. **Download** [`ide-rules-opencode.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-opencode.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.opencode/` directory to your project root:
 
@@ -212,7 +212,7 @@ Select your AI coding tool and follow the instructions:
 
     **Option A: Pre-built download (recommended)**
 
-    1. **Download** [`ide-rules-codex.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-codex.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.agents/` directory to your project root (Codex
        discovers skills under `.agents/skills/`):
@@ -246,7 +246,7 @@ Select your AI coding tool and follow the instructions:
 
     OpenClaw uses the [Agent Skills standard](https://agentskills.io/) for skill discovery.
 
-    1. **Download** [`ide-rules-openclaw.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-openclaw.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.openclaw/` directory to your project root:
 
@@ -260,7 +260,7 @@ Select your AI coding tool and follow the instructions:
 
     Hermes uses the [Agent Skills standard](https://agentskills.io/) for skill discovery.
 
-    1. **Download** [`ide-rules-hermes.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
+    1. **Download** [`codeguard-hermes.zip`](https://github.com/cosai-oasis/project-codeguard/releases) from the Releases page
     2. **Extract** the ZIP file
     3. **Copy** the `.hermes/` directory to your project root:
 
@@ -270,7 +270,7 @@ Select your AI coding tool and follow the instructions:
 
     4. **Start a new session** in Hermes to load the rules
 
-**Using multiple tools?** Download [`ide-rules-all.zip`](https://github.com/cosai-oasis/project-codeguard/releases) for all formats in one archive.
+**Using multiple tools?** Download [`codeguard-all.zip`](https://github.com/cosai-oasis/project-codeguard/releases) for all formats in one archive.
 
 !!! tip "Repository Level Installation"
     Installing at the repository level ensures all team members benefit from the security rules automatically when they clone the repository.
@@ -330,11 +330,11 @@ Project CodeGuard supports two rule activation types:
 - **Always-on rules**: Apply to all files in the project. These rules are for baseline safeguards that should always be in context.
 - **Glob-scoped rules**: Apply only to matching file patterns (derived from `languages` in source frontmatter). These rules are for language- or framework-specific guidance.
 
-## Keeping Rules Updated (Automated)
+## Keeping Vendored Rules Updated (Optional)
 
 Typically owned by the **Application Developer** persona (repository maintainer) with **AI System Governance** reviewing and merging update PRs to keep policy current.
 
-For GitHub repositories, you can automate rule updates with a workflow that runs monthly and creates PRs when new versions are available.
+For GitHub repositories that copy CodeGuard files directly into source control, you can optionally automate rule updates with a workflow that runs monthly and creates PRs when new versions are available. This is not needed for install paths that already update through a plugin, marketplace, or remote instructions.
 
 ### Supported Formats
 
@@ -354,6 +354,8 @@ For GitHub repositories, you can automate rule updates with a workflow that runs
 3. Commit and push
 
 The workflow runs monthly (1st at 9:00 UTC) and can also be triggered manually from the **Actions** tab.
+
+This workflow refreshes CodeGuard rule files only. To update bundled skills, agents, or other generated support files, re-download the release archive for your tool.
 
 ## Verify Installation
 

--- a/docs/install-paths.md
+++ b/docs/install-paths.md
@@ -80,7 +80,7 @@ Before picking a mechanism, decide **who** should end up with CodeGuard active. 
     **Admin responsibilities**
 
     - Requires write access to the repo and a reviewed PR to land the rule files.
-    - Someone on the team owns updates — either manually on each CodeGuard release or via the [auto-update GitHub Action](getting-started.md#keeping-rules-updated-automated), which still needs a reviewer to merge its PRs.
+    - Someone on the team owns updates — either manually on each CodeGuard release or via the [optional auto-update GitHub Action](getting-started.md#keeping-vendored-rules-updated-optional), which still needs a reviewer to merge its PRs.
     - Rule changes are visible in diff/PR history, so treat them like any other code change (review, CODEOWNERS, branch protection).
     - If contributors use different AI tools, you may need to commit multiple format directories (`.cursor/`, `.windsurf/`, `.github/`, …) and keep them in sync.
 
@@ -117,7 +117,7 @@ Static markdown files the AI tool reads from a known directory. Each rule declar
 
 - **Supported by:** Cursor (`.cursor/rules/`), Windsurf (`.windsurf/rules/`), GitHub Copilot (`.github/instructions/`), Antigravity (`.agents/rules/`)
 - **Best for:** Most users. Predictable, version-controlled, diffable in PRs.
-- **Tradeoffs:** You update by re-downloading (or use the [auto-update workflow](getting-started.md#keeping-rules-updated-automated)).
+- **Tradeoffs:** You update by re-downloading (or use the [optional auto-update workflow](getting-started.md#keeping-vendored-rules-updated-optional)).
 - **Responsible CoSAI personas:** Application Developer, with AI System Governance for policy review in PRs.
 
 ### Agent Skills

--- a/src/formats/claude.py
+++ b/src/formats/claude.py
@@ -1,7 +1,7 @@
 """Claude Code bundle format.
 
 Emits rule files under ``.claude/skills/codeguard/rules/`` so the
-release bundle (``ide-rules-claude.zip``) ships the full skill alongside
+release bundle (``codeguard-claude.zip``) ships the full skill alongside
 the ``codeguard-reviewer`` subagent — parity with the per-host bundles
 for OpenCode, Codex, OpenClaw, and Hermes. The Claude Code plugin remains
 the recommended install path; this bundle is the drop-in-a-repo alternative.


### PR DESCRIPTION
## Summary

Renames release archive assets from `ide-rules-*` to `codeguard-*` and updates the matching docs and updater references.

## Changes

- Publishes `codeguard-*.zip` release archives and `SHA256SUMS`
- Updates install docs to reference the new asset names
- Updates the optional updater workflow to consume the new asset names
- Adds OpenClaw and Hermes to the updater format map

## Validation

- `uv run mkdocs build --strict`
- `uv run python src/validate_unified_rules.py sources/`