### PR TITLE
fix: upgrade joserfc to address Dependabot alert

### DIFF
--- a/src/codeguard-mcp/pyproject.toml
+++ b/src/codeguard-mcp/pyproject.toml
@@ -26,6 +26,7 @@ constraint-dependencies = [
     "authlib>=1.6.12",  # via fastmcp
     "cryptography>=48.0.1",  # via authlib and pyjwt
     "idna>=3.15",  # via httpx
+    "joserfc>=1.6.8",  # via authlib
     "pyjwt>=2.13.0",  # via mcp
     "python-multipart>=0.0.31",  # via mcp
     "starlette>=1.3.1",  # via mcp and sse-starlette

--- a/src/codeguard-mcp/uv.lock
+++ b/src/codeguard-mcp/uv.lock
@@ -7,6 +7,7 @@ constraints = [
     { name = "authlib", specifier = ">=1.6.12" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "idna", specifier = ">=3.15" },
+    { name = "joserfc", specifier = ">=1.6.8" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "starlette", specifier = ">=1.3.1" },
@@ -537,14 +538,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.7"
+version = "1.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/cb/52e479f20804904f5df20ac4539d292dcecd1287aaa33cba1d1def1d9d8e/joserfc-1.6.7.tar.gz", hash = "sha256:6999fe89457069ecacd8cc797c88a805f83054dd883333fa0409f74b46479fd7", size = 232158, upload-time = "2026-05-23T01:46:44.069Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/c6/b1cac0280f8efc57626ea8804866b37099f23cae11b1485a42b213245e31/joserfc-1.7.3.tar.gz", hash = "sha256:116955c2587139dba20621fd0bd7fc9255fa960c9fe7f43c43ebef2e801dcfcf", size = 233821, upload-time = "2026-07-08T12:41:42.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/e4/bcf6718b5662894c6831f46296b73cd4b1a2e90c20b6d437e20c4997388c/joserfc-1.6.7-py3-none-any.whl", hash = "sha256:9e51e4a64840aa1734a058258e80a4480e2ff2d5686e480e7c92c954a92fbe05", size = 70603, upload-time = "2026-05-23T01:46:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/650b59d1b74f5befb7a7a7e7d7c92a26b94256df3541e2b4914152cd177a/joserfc-1.7.3-py3-none-any.whl", hash = "sha256:7c39f3f2c943dbc03122747fa8ebbd8e156e54904cf25651b452f4d2634a6075", size = 70982, upload-time = "2026-07-08T12:41:41.521Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require `joserfc>=1.6.8` as a transitive security floor
- update the lockfile from `joserfc` 1.6.7 to 1.7.3

## Why

This resolves Dependabot alert 31. Affected `joserfc` versions can accept an empty HMAC verification key, allowing forged JWTs when an application supplies a missing or empty secret. The fixed release rejects empty keys instead.

## Validation

- `uv lock --check`
- `uv run pytest` — 18 passed
- verified that `OctKey.import_key("")` is rejected
