### PR TITLE
chore: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/build-ide-bundles.yml
+++ b/.github/workflows/build-ide-bundles.yml
@@ -13,17 +13,17 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,17 +19,17 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -43,4 +43,3 @@ jobs:
 
       - name: Deploy to GitHub Pages
         run: uv run mkdocs gh-deploy --force --clean --verbose
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@
           pull-requests: write
     
         steps:
-          - uses: actions/stale@v9
+          - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
             with:
               # The token for the repository. Required.
               repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-codeguard-rules.yml
+++ b/.github/workflows/update-codeguard-rules.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -28,15 +28,15 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary

- pin every third-party action used by the repository workflows to a full 40-character commit SHA
- retain each action's semantic version as an inline comment for readability and update tooling
- cover the release, documentation, validation, stale-management, and rule-update workflows

## Why

Mutable action tags can be retargeted after review. Immutable revisions reduce that supply-chain risk and implement the GitHub Actions SHA-pinning follow-up identified in #35. Cosign release signing remains out of scope for a separate change.

## Validation

- confirmed all 11 `uses:` references are pinned to 40-character SHAs
- parsed all five workflow YAML files successfully
- validated all 108 CodeGuard rules
- converted all 23 core rules successfully

Related to #35.
