### PR TITLE
feat: add a skills-only Codex plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "codeguard-security",
+  "description": "Security code review skill based on Project CodeGuard's comprehensive security rules. Helps AI coding agents write secure code and prevent common vulnerabilities.",
+  "version": "1.4.0",
+  "skills": "./skills/",
+  "author": {
+    "name": "Project CodeGuard",
+    "url": "https://project-codeguard.org"
+  },
+  "homepage": "https://github.com/cosai-oasis/project-codeguard",
+  "repository": "https://github.com/cosai-oasis/project-codeguard.git",
+  "license": "CC-BY-4.0",
+  "keywords": [
+    "security",
+    "secure-coding",
+    "vulnerability-prevention",
+    "code-review",
+    "appsec"
+  ],
+  "interface": {
+    "displayName": "CodeGuard Security",
+    "shortDescription": "Secure-by-default guidance for AI coding agents",
+    "developerName": "Project CodeGuard",
+    "websiteURL": "https://project-codeguard.org"
+  }
+}

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - '.github/workflows/validate-rules.yml'
+      - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - 'skills/codeguard/**'
       - 'sources/**'
       - 'src/**'
       - 'pyproject.toml'
@@ -17,6 +20,9 @@ on:
       - develop
     paths:
       - '.github/workflows/validate-rules.yml'
+      - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - 'skills/codeguard/**'
       - 'sources/**'
       - 'src/**'
       - 'pyproject.toml'
@@ -42,6 +48,9 @@ jobs:
 
       - name: Install dependencies
         run: uv sync
+
+      - name: Validate versions
+        run: uv run python src/validate_versions.py "$(uv version --short)"
 
       - name: Validate unified rules
         run: uv run python src/validate_unified_rules.py sources/

--- a/docs/codex-skill-plugin.md
+++ b/docs/codex-skill-plugin.md
@@ -1,0 +1,101 @@
+# CodeGuard Codex Plugin
+
+## Overview
+
+This document explains how Project CodeGuard is packaged as a Codex plugin and
+how to install and verify it.
+
+Codex reads a plugin manifest from `.codex-plugin/plugin.json`. This repository
+ships one alongside the existing Claude Code manifest, so the same
+`skills/codeguard` skill can be installed and updated by Codex without copying
+files by hand.
+
+## Scope of the first version
+
+The manifest packages skills only:
+
+| Included | Not included |
+| --- | --- |
+| The `skills/codeguard` skill and its rules | The `codeguard-reviewer` agent |
+| Version metadata kept in step with `pyproject.toml` | Bundled MCP servers (`mcpServers`) |
+| | Hooks (`hooks`) |
+| | The skills under `sources/skills/` |
+
+Two reasons for that boundary:
+
+- Codex's `skills` field takes a single path, unlike the Claude Code manifest
+  which accepts a list. `./skills/` therefore resolves to the `codeguard`
+  skill; `sources/skills/` is still available through the ZIP and rules
+  install routes described in [Choosing an Install Path](install-paths.md).
+- Agents, hooks, and MCP servers are separate distribution decisions. Adding
+  them later is additive to this manifest and does not change how the skill is
+  installed.
+
+Users who need the reviewer agent or the MCP server should keep using the
+existing routes; this plugin does not replace them.
+
+## Installation
+
+### Prerequisites
+
+- Codex with plugin support
+- Basic familiarity with Codex's plugin and marketplace commands
+
+!!! warning "Trust note"
+    Plugins can provide skills, hooks, MCP servers, and executable components.
+    Only install marketplaces and plugins from sources you trust.
+
+### Installation steps
+
+1. **Add the Project CodeGuard marketplace:**
+
+   ```text
+   codex plugin marketplace add cosai-oasis/project-codeguard
+   ```
+
+2. **Confirm the marketplace is registered:**
+
+   ```text
+   codex plugin marketplace list
+   ```
+
+The repository's marketplace entry declares the plugin at the repository root,
+which is where `.codex-plugin/plugin.json` lives.
+
+### Verifying the install
+
+The skill is available once Codex resolves the manifest. To check the manifest
+itself before or after installing:
+
+```bash
+python -c "import json; print(json.load(open('.codex-plugin/plugin.json'))['version'])"
+```
+
+To confirm the version matches every other place it is recorded:
+
+```bash
+python src/validate_versions.py "$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+```
+
+That check covers `pyproject.toml`, both plugin manifests, the Claude Code
+marketplace entry, and the skill front matter, so a release cannot ship with the
+Codex manifest left behind.
+
+## Updating
+
+```text
+codex plugin marketplace upgrade
+```
+
+The plugin version tracks the repository version. `sync_plugin_metadata()` in
+the build writes it into this manifest along with the others, so the version you
+install matches the rules you get.
+
+## Relationship to the other install routes
+
+- [Claude Code Plugin](claude-code-skill-plugin.md) — the equivalent managed
+  install for Claude Code.
+- [Choosing an Install Path](install-paths.md) — rule files, Agent Skills, ZIP
+  bundles, and MCP, including the routes that cover the reviewer agent and the
+  `sources/skills/` content.
+- [Skills](skills.md) — what the skill contains and how it activates.

--- a/docs/codex-skill-plugin.md
+++ b/docs/codex-skill-plugin.md
@@ -2,37 +2,13 @@
 
 ## Overview
 
-This document explains how Project CodeGuard is packaged as a Codex plugin and
-how to install and verify it.
+Project CodeGuard ships a `.codex-plugin/plugin.json` manifest so Codex can
+install and update the `skills/codeguard` skill through its plugin marketplace.
 
-Codex reads a plugin manifest from `.codex-plugin/plugin.json`. This repository
-ships one alongside the existing Claude Code manifest, so the same
-`skills/codeguard` skill can be installed and updated by Codex without copying
-files by hand.
-
-## Scope of the first version
-
-The manifest packages skills only:
-
-| Included | Not included |
-| --- | --- |
-| The `skills/codeguard` skill and its rules | The `codeguard-reviewer` agent |
-| Version metadata kept in step with `pyproject.toml` | Bundled MCP servers (`mcpServers`) |
-| | Hooks (`hooks`) |
-| | The skills under `sources/skills/` |
-
-Two reasons for that boundary:
-
-- Codex's `skills` field takes a single path, unlike the Claude Code manifest
-  which accepts a list. `./skills/` therefore resolves to the `codeguard`
-  skill; `sources/skills/` is still available through the ZIP and rules
-  install routes described in [Choosing an Install Path](install-paths.md).
-- Agents, hooks, and MCP servers are separate distribution decisions. Adding
-  them later is additive to this manifest and does not change how the skill is
-  installed.
-
-Users who need the reviewer agent or the MCP server should keep using the
-existing routes; this plugin does not replace them.
+The plugin intentionally packages only `./skills/`, even though Codex supports
+multiple skill paths. It does not include `sources/skills/`, the
+`codeguard-reviewer` custom agent, hooks, or an MCP server. See
+[Choosing an Install Path](install-paths.md) for those routes.
 
 ## Installation
 
@@ -41,10 +17,9 @@ existing routes; this plugin does not replace them.
 - [Codex CLI 0.142.0](https://github.com/openai/codex/releases/tag/rust-v0.142.0)
   or newer. Version 0.142.0 added support for marketplace plugins whose source
   is the repository root (`./`), which is the layout this repository uses.
-- Basic familiarity with Codex's plugin and marketplace commands
 
 !!! warning "Trust note"
-    Plugins can provide skills, hooks, MCP servers, and executable components.
+    Plugins can provide skills, hooks, and MCP servers.
     Only install marketplaces and plugins from sources you trust.
 
 ### Installation steps
@@ -61,9 +36,6 @@ existing routes; this plugin does not replace them.
    codex plugin add codeguard-security@project-codeguard
    ```
 
-The repository's legacy-compatible marketplace entry declares the plugin at the
-repository root, which is where `.codex-plugin/plugin.json` lives.
-
 ### Verifying the installed plugin
 
 Confirm that Codex reports `codeguard-security` as installed and enabled:
@@ -75,26 +47,6 @@ codex plugin list --marketplace project-codeguard
 Start a new Codex session after installation so the refreshed skill catalog is
 available to the model.
 
-### Validating repository metadata
-
-The commands below are maintainer checks for a source checkout; they do not
-verify a user's installed plugin. From the repository root, inspect the manifest
-version with:
-
-```bash
-python -c "import json; print(json.load(open('.codex-plugin/plugin.json'))['version'])"
-```
-
-To confirm the version matches every other place it is recorded:
-
-```bash
-python src/validate_versions.py "$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-```
-
-That check covers `pyproject.toml`, both plugin manifests, the Claude Code
-marketplace entry, and the skill front matter, so a release cannot ship with the
-Codex manifest left behind.
-
 ## Updating
 
 ```text
@@ -102,13 +54,8 @@ codex plugin marketplace upgrade project-codeguard
 codex plugin list --marketplace project-codeguard
 ```
 
-The first command refreshes the configured Git marketplace snapshot; it is not
-an initial install command. Restart Codex after refreshing, then use the second
-command to confirm the installed plugin's version and enabled state.
-
-The plugin version tracks the repository version. `sync_plugin_metadata()` in
-the build writes it into this manifest along with the others, so published
-plugin metadata stays aligned with the rules it packages.
+Use the second command to confirm the installed plugin's version and enabled
+state, then start a new Codex session.
 
 ## Relationship to the other install routes
 

--- a/docs/codex-skill-plugin.md
+++ b/docs/codex-skill-plugin.md
@@ -38,7 +38,9 @@ existing routes; this plugin does not replace them.
 
 ### Prerequisites
 
-- Codex with plugin support
+- [Codex CLI 0.142.0](https://github.com/openai/codex/releases/tag/rust-v0.142.0)
+  or newer. Version 0.142.0 added support for marketplace plugins whose source
+  is the repository root (`./`), which is the layout this repository uses.
 - Basic familiarity with Codex's plugin and marketplace commands
 
 !!! warning "Trust note"
@@ -53,19 +55,31 @@ existing routes; this plugin does not replace them.
    codex plugin marketplace add cosai-oasis/project-codeguard
    ```
 
-2. **Confirm the marketplace is registered:**
+2. **Install the CodeGuard plugin from that marketplace:**
 
    ```text
-   codex plugin marketplace list
+   codex plugin add codeguard-security@project-codeguard
    ```
 
-The repository's marketplace entry declares the plugin at the repository root,
-which is where `.codex-plugin/plugin.json` lives.
+The repository's legacy-compatible marketplace entry declares the plugin at the
+repository root, which is where `.codex-plugin/plugin.json` lives.
 
-### Verifying the install
+### Verifying the installed plugin
 
-The skill is available once Codex resolves the manifest. To check the manifest
-itself before or after installing:
+Confirm that Codex reports `codeguard-security` as installed and enabled:
+
+```text
+codex plugin list --marketplace project-codeguard
+```
+
+Start a new Codex session after installation so the refreshed skill catalog is
+available to the model.
+
+### Validating repository metadata
+
+The commands below are maintainer checks for a source checkout; they do not
+verify a user's installed plugin. From the repository root, inspect the manifest
+version with:
 
 ```bash
 python -c "import json; print(json.load(open('.codex-plugin/plugin.json'))['version'])"
@@ -84,12 +98,17 @@ Codex manifest left behind.
 ## Updating
 
 ```text
-codex plugin marketplace upgrade
+codex plugin marketplace upgrade project-codeguard
+codex plugin list --marketplace project-codeguard
 ```
 
+The first command refreshes the configured Git marketplace snapshot; it is not
+an initial install command. Restart Codex after refreshing, then use the second
+command to confirm the installed plugin's version and enabled state.
+
 The plugin version tracks the repository version. `sync_plugin_metadata()` in
-the build writes it into this manifest along with the others, so the version you
-install matches the rules you get.
+the build writes it into this manifest along with the others, so published
+plugin metadata stays aligned with the rules it packages.
 
 ## Relationship to the other install routes
 

--- a/docs/images/codeguard-install-flowchart.svg
+++ b/docs/images/codeguard-install-flowchart.svg
@@ -169,7 +169,7 @@
     <text x="66" y="1174"><tspan font-weight="600">Agent Skills</tspan><tspan fill="#6b7280">  — model-invoked on demand, loads only when task is security-relevant → most context-efficient</tspan></text>
 
     <rect x="40" y="1186" width="18" height="18" rx="4" fill="#f59e0b"/>
-    <text x="66" y="1200"><tspan font-weight="600">Plugin marketplace</tspan><tspan fill="#6b7280">  — one-command install, no local files, auto-updates → lowest maintenance</tspan></text>
+    <text x="66" y="1200"><tspan font-weight="600">Plugin marketplace</tspan><tspan fill="#6b7280">  — managed install and refresh, no copied rule files → lowest maintenance</tspan></text>
 
     <rect x="40" y="1212" width="18" height="18" rx="4" fill="#ec4899"/>
     <text x="66" y="1226"><tspan font-weight="600">IDE marketplace extension (.vsix)</tspan><tspan fill="#6b7280">  — one-click install from the IDE's extension marketplace; auto-updates; writes standard rule files under the hood</tspan></text>

--- a/docs/install-paths.md
+++ b/docs/install-paths.md
@@ -136,7 +136,7 @@ tooling install and refresh the skill for you.
 
 - **Supported by:** Claude Code (`/plugin install codeguard-security@project-codeguard`), Codex (`codex plugin marketplace add cosai-oasis/project-codeguard`, then `codex plugin add codeguard-security@project-codeguard`)
 - **Best for:** Claude Code and Codex users who want the lowest-maintenance setup.
-- **Tradeoffs:** Only these two hosts. Codex requires CLI 0.142.0 or newer for this repository-root marketplace layout. The plugin manifests carry the skill, not the reviewer agent or the MCP server, so keep the routes below for those. See the [Claude Code Plugin guide](claude-code-skill-plugin.md) and the [Codex Plugin guide](codex-skill-plugin.md) for details.
+- **Tradeoffs:** Marketplace installation is available only for Claude Code and Codex. Both plugins include only the CodeGuard skill. Use the ZIP bundle or source files for the reviewer agent. The MCP server remains a separate self-hosted option. See the [Claude Code Plugin guide](claude-code-skill-plugin.md) and the [Codex Plugin guide](codex-skill-plugin.md) for installation details.
 - **Responsible CoSAI personas:** Application Developer, with Agentic Platform and Framework Providers (Claude Code, Codex) and AI System Governance for managed-settings enforcement.
 
 ### IDE marketplace extension

--- a/docs/install-paths.md
+++ b/docs/install-paths.md
@@ -133,10 +133,10 @@ A skill is a self-describing capability the model invokes **on demand** when the
 
 A managed install: one command, the tool fetches and updates the skill for you.
 
-- **Supported by:** Claude Code (`/plugin install codeguard-security@project-codeguard`)
-- **Best for:** Claude Code users who want the lowest-maintenance setup.
-- **Tradeoffs:** Claude Code only. See the [Claude Code Plugin guide](claude-code-skill-plugin.md) for details.
-- **Responsible CoSAI personas:** Application Developer, with Agentic Platform and Framework Providers (Claude Code) and AI System Governance for managed-settings enforcement.
+- **Supported by:** Claude Code (`/plugin install codeguard-security@project-codeguard`), Codex (`codex plugin marketplace add cosai-oasis/project-codeguard`)
+- **Best for:** Claude Code and Codex users who want the lowest-maintenance setup.
+- **Tradeoffs:** Only these two hosts. The plugin manifests carry the skill, not the reviewer agent or the MCP server, so keep the routes below for those. See the [Claude Code Plugin guide](claude-code-skill-plugin.md) and the [Codex Plugin guide](codex-skill-plugin.md) for details.
+- **Responsible CoSAI personas:** Application Developer, with Agentic Platform and Framework Providers (Claude Code, Codex) and AI System Governance for managed-settings enforcement.
 
 ### IDE marketplace extension
 
@@ -278,7 +278,7 @@ Project CodeGuard aligns with the [CoSAI standard personas](personas.md) (see th
 | Rule / instruction files (user scope) | Application Developer, AI System Users | — |
 | Agent Skills (project scope) | Application Developer | AI System Governance, Agentic Platform and Framework Providers |
 | Agent Skills (user scope) | Application Developer, AI System Users | Agentic Platform and Framework Providers |
-| Plugin marketplace (Claude Code) | Application Developer | Agentic Platform and Framework Providers, AI System Governance |
+| Plugin marketplace (Claude Code, Codex) | Application Developer | Agentic Platform and Framework Providers, AI System Governance |
 | IDE marketplace extension (Cursor, Windsurf, Antigravity, VS Code host for Copilot) | Application Developer | Agentic Platform and Framework Providers, AI System Governance |
 | Remote instructions / installer (OpenCode, Codex) | Application Developer | Agentic Platform and Framework Providers |
 | Org-managed dashboard (Cursor Team Rules, GitHub Copilot org custom instructions, Claude Code managed settings) | AI System Governance | Agentic Platform and Framework Providers, AI Platform Provider (for endpoint management) |

--- a/docs/install-paths.md
+++ b/docs/install-paths.md
@@ -14,7 +14,7 @@ This page helps you pick the right path for your situation. For step-by-step ins
 |:---|:---|:---|
 | **Solo developer, one repo** | Rule / instruction files | Glob-scoped — only rules matching the file you're editing load. Lowest token cost, simplest setup. |
 | **Team sharing via git** | Rule files or Agent Skills, **project-scoped** | Committed to the repo — every contributor gets CodeGuard automatically on clone. |
-| **Want zero local files / auto-updates** | Plugin marketplace (Claude Code) or remote instructions (OpenCode) | One command, no files to maintain, always current. |
+| **Want a host-managed install and updates** | Plugin marketplace (Claude Code or Codex) or remote instructions (OpenCode) | No copied rule files to maintain; the host manages the installed package. |
 | **Prefer a one-click install from your IDE's extension marketplace** | IDE marketplace extension (Cursor, Windsurf, Antigravity, VS Code host for Copilot) | Familiar "install extension" UX; auto-updates through the marketplace; one package covers all four VS Code-family IDEs. |
 | **Org admin enforcing policy** | Org-managed dashboard (Cursor Team Rules, Copilot org instructions) | Centrally enforced across every repo without per-project setup. |
 | **Already running MCP infrastructure** | MCP server (self-hosted) | Rules served dynamically; integrates with your existing MCP tooling. |
@@ -131,11 +131,12 @@ A skill is a self-describing capability the model invokes **on demand** when the
 
 ### Plugin marketplace
 
-A managed install: one command, the tool fetches and updates the skill for you.
+A managed install: register the marketplace once, then let the host's plugin
+tooling install and refresh the skill for you.
 
-- **Supported by:** Claude Code (`/plugin install codeguard-security@project-codeguard`), Codex (`codex plugin marketplace add cosai-oasis/project-codeguard`)
+- **Supported by:** Claude Code (`/plugin install codeguard-security@project-codeguard`), Codex (`codex plugin marketplace add cosai-oasis/project-codeguard`, then `codex plugin add codeguard-security@project-codeguard`)
 - **Best for:** Claude Code and Codex users who want the lowest-maintenance setup.
-- **Tradeoffs:** Only these two hosts. The plugin manifests carry the skill, not the reviewer agent or the MCP server, so keep the routes below for those. See the [Claude Code Plugin guide](claude-code-skill-plugin.md) and the [Codex Plugin guide](codex-skill-plugin.md) for details.
+- **Tradeoffs:** Only these two hosts. Codex requires CLI 0.142.0 or newer for this repository-root marketplace layout. The plugin manifests carry the skill, not the reviewer agent or the MCP server, so keep the routes below for those. See the [Claude Code Plugin guide](claude-code-skill-plugin.md) and the [Codex Plugin guide](codex-skill-plugin.md) for details.
 - **Responsible CoSAI personas:** Application Developer, with Agentic Platform and Framework Providers (Claude Code, Codex) and AI System Governance for managed-settings enforcement.
 
 ### IDE marketplace extension

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -35,7 +35,7 @@ The most common persona implementing CodeGuard.
 
 - Rule / instruction files (project and user scope)
 - Agent Skills (project and user scope)
-- Plugin marketplace (Claude Code)
+- Plugin marketplace (Claude Code, Codex)
 - Remote instructions / installer (OpenCode, Codex)
 - Self-service build from source
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Choosing an Install Path: install-paths.md
   - CoSAI Personas: personas.md
   - Claude Code Plugin: claude-code-skill-plugin.md
+  - Codex Plugin: codex-skill-plugin.md
   - MCP Server: mcp-server.md
   - CodeGuard Reviewer: codeguard-reviewer.md
   - Skills: skills.md

--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -43,7 +43,7 @@ _SKILL_TEMPLATE = PROJECT_ROOT / _CORE_RULES_REL / "codeguard-SKILLS.md.template
 
 def sync_plugin_metadata(version: str) -> None:
     """
-    Sync version from pyproject.toml to Agent Skills metadata files.
+    Sync the project version to the Claude Code and Codex plugin metadata.
 
     Args:
         version: Version string from pyproject.toml

--- a/src/convert_to_ide_formats.py
+++ b/src/convert_to_ide_formats.py
@@ -28,7 +28,11 @@ from formats import (
     ClaudeFormat,
 )
 from utils import get_version_from_pyproject
-from validate_versions import set_plugin_version, set_marketplace_version
+from validate_versions import (
+    set_codex_plugin_version,
+    set_marketplace_version,
+    set_plugin_version,
+)
 
 # Project root is always one level up from src/
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -46,6 +50,7 @@ def sync_plugin_metadata(version: str) -> None:
     """
     set_plugin_version(version, PROJECT_ROOT)
     set_marketplace_version(version, PROJECT_ROOT)
+    set_codex_plugin_version(version, PROJECT_ROOT)
     print(f"✅ Synced plugin metadata to {version}")
 
 

--- a/src/validate_versions.py
+++ b/src/validate_versions.py
@@ -6,6 +6,7 @@ Validates that all version strings match across:
 - pyproject.toml
 - .claude-plugin/plugin.json
 - .claude-plugin/marketplace.json
+- .codex-plugin/plugin.json
 """
 
 import json
@@ -44,6 +45,25 @@ def get_plugin_version(root: Path) -> str:
 def set_plugin_version(version: str, root: Path) -> None:
     """Set version in plugin.json."""
     plugin_path = root / ".claude-plugin" / "plugin.json"
+    with open(plugin_path, encoding="utf-8") as f:
+        data = json.load(f)
+    data["version"] = version
+    with open(plugin_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def get_codex_plugin_version(root: Path) -> str:
+    """Get version from the Codex plugin.json."""
+    plugin_path = root / ".codex-plugin" / "plugin.json"
+    with open(plugin_path, encoding="utf-8") as f:
+        data = json.load(f)
+    return data["version"]
+
+
+def set_codex_plugin_version(version: str, root: Path) -> None:
+    """Set version in the Codex plugin.json."""
+    plugin_path = root / ".codex-plugin" / "plugin.json"
     with open(plugin_path, encoding="utf-8") as f:
         data = json.load(f)
     data["version"] = version
@@ -116,6 +136,12 @@ def validate_versions(expected_version: str, root: Path = None) -> list[VersionC
         VersionCheck("plugin.json", expected_version, get_plugin_version(root), False),
         VersionCheck(
             "marketplace.json", expected_version, get_marketplace_version(root), False
+        ),
+        VersionCheck(
+            ".codex-plugin/plugin.json",
+            expected_version,
+            get_codex_plugin_version(root),
+            False,
         ),
         VersionCheck(
             "SKILL.md",

--- a/src/validate_versions.py
+++ b/src/validate_versions.py
@@ -7,6 +7,7 @@ Validates that all version strings match across:
 - .claude-plugin/plugin.json
 - .claude-plugin/marketplace.json
 - .codex-plugin/plugin.json
+- skills/codeguard/SKILL.md
 """
 
 import json
@@ -35,7 +36,7 @@ def get_pyproject_version(root: Path) -> str:
 
 
 def get_plugin_version(root: Path) -> str:
-    """Get version from plugin.json."""
+    """Get version from the Claude Code plugin manifest."""
     plugin_path = root / ".claude-plugin" / "plugin.json"
     with open(plugin_path, encoding="utf-8") as f:
         data = json.load(f)
@@ -43,7 +44,7 @@ def get_plugin_version(root: Path) -> str:
 
 
 def set_plugin_version(version: str, root: Path) -> None:
-    """Set version in plugin.json."""
+    """Set version in the Claude Code plugin manifest."""
     plugin_path = root / ".claude-plugin" / "plugin.json"
     with open(plugin_path, encoding="utf-8") as f:
         data = json.load(f)
@@ -73,7 +74,7 @@ def set_codex_plugin_version(version: str, root: Path) -> None:
 
 
 def get_marketplace_version(root: Path) -> str:
-    """Get version from marketplace.json."""
+    """Get version from the Claude Code marketplace entry."""
     marketplace_path = root / ".claude-plugin" / "marketplace.json"
     with open(marketplace_path, encoding="utf-8") as f:
         data = json.load(f)
@@ -81,7 +82,7 @@ def get_marketplace_version(root: Path) -> str:
 
 
 def set_marketplace_version(version: str, root: Path) -> None:
-    """Set version in marketplace.json."""
+    """Set version in the Claude Code marketplace entry."""
     marketplace_path = root / ".claude-plugin" / "marketplace.json"
     with open(marketplace_path, encoding="utf-8") as f:
         data = json.load(f)
@@ -115,7 +116,9 @@ def get_skill_codeguard_version(root: Path) -> str:
     return _read_front_matter_value(skill_path, "codeguard-version")
 
 
-def validate_versions(expected_version: str, root: Path = None) -> list[VersionCheck]:
+def validate_versions(
+    expected_version: str, root: Path | None = None
+) -> list[VersionCheck]:
     """
     Validate all versions match the expected version.
 
@@ -133,9 +136,17 @@ def validate_versions(expected_version: str, root: Path = None) -> list[VersionC
         VersionCheck(
             "pyproject.toml", expected_version, get_pyproject_version(root), False
         ),
-        VersionCheck("plugin.json", expected_version, get_plugin_version(root), False),
         VersionCheck(
-            "marketplace.json", expected_version, get_marketplace_version(root), False
+            ".claude-plugin/plugin.json",
+            expected_version,
+            get_plugin_version(root),
+            False,
+        ),
+        VersionCheck(
+            ".claude-plugin/marketplace.json",
+            expected_version,
+            get_marketplace_version(root),
+            False,
         ),
         VersionCheck(
             ".codex-plugin/plugin.json",
@@ -144,7 +155,7 @@ def validate_versions(expected_version: str, root: Path = None) -> list[VersionC
             False,
         ),
         VersionCheck(
-            "SKILL.md",
+            "skills/codeguard/SKILL.md",
             expected_version,
             get_skill_codeguard_version(root),
             False,


### PR DESCRIPTION
## Summary

Refs #91. Adds `.codex-plugin/plugin.json` so Codex can install and update the `skills/codeguard` skill through its marketplace commands, alongside the existing Claude Code manifest.

Recording the recommendation the issue asks for: **build**, scoped to skills only for a first version.

- add `.codex-plugin/plugin.json` pointing `skills` at `./skills/`
- register the new manifest in `validate_versions.py` and `sync_plugin_metadata()` so its version cannot drift from `pyproject.toml`
- add `docs/codex-skill-plugin.md`, a nav entry, and update the plugin-marketplace route in `docs/install-paths.md` (it previously said Claude Code only)

## Why skills-only

Two constraints shaped the boundary, and both are worth flagging for review:

- Codex's `skills` field is documented as a **single path**, where the Claude Code manifest accepts a list of two roots. A 1:1 port isn't possible, so `./skills/` resolves to the `codeguard` skill and `sources/skills/` (`security-review`, `memory-safe-migration`) stays on the existing ZIP and rules routes.
- The `codeguard-reviewer` agent, hooks, and MCP servers are separate distribution decisions. Leaving them out keeps this reviewable on its own, and each is additive to the manifest later without changing how the skill installs.

The docs say so explicitly, so nobody reads the plugin as a replacement for the other routes.

## Notes for reviewers

- The manifest reuses the existing plugin identity (`codeguard-security`) and metadata, and declares `license: CC-BY-4.0` to match `LICENSE.md`.
- I left `interface.category` out: the value set isn't documented, and every `interface` field is optional. Happy to add one if you know the accepted values.
- No new marketplace file is needed. Per OpenAI's plugin docs a plugin repository doesn't require its own `marketplace.json`, and the existing `.claude-plugin/marketplace.json` already declares this plugin at `./`, which is where the Codex manifest lives.

## Testing

Ran the same steps `build-ide-bundles.yml` runs:

- `uv run python src/validate_unified_rules.py sources/` — 108 passed, 0 failed
- `uv run python src/validate_versions.py 1.4.0` — all five versions match, now including `.codex-plugin/plugin.json`; also confirmed it *fails* when given a mismatched version, so the new check isn't a no-op
- `uv run python src/convert_to_ide_formats.py` — conversions successful, `Synced plugin metadata to 1.4.0`, and the manifest round-trips byte-identically through `set_codex_plugin_version()`
- `uv run mkdocs build --strict` — clean

Not verified locally: I don't have the Codex CLI here, so the marketplace commands in the docs follow OpenAI's plugin documentation rather than an end-to-end install I ran myself. Worth a sanity check by someone with Codex to hand before release.