### PR TITLE
fix: make CodeGuard publish address configurable

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -23,6 +23,14 @@ cd src/codeguard-mcp
 docker compose up --build
 ```
 
+Docker Compose publishes the server on `127.0.0.1` by default. Keep that default
+when the reverse proxy runs on the Docker host. If the proxy runs on another
+host, set `CODEGUARD_PUBLISH_ADDRESS` to a specific private interface and use
+firewall or security-group rules to allow the published port only from the
+proxy. The proxy must provide TLS and authentication. Do not publish on
+`0.0.0.0` unless equivalent network controls prevent direct access to the
+backend port.
+
 ## Connect Your IDE
 
 Add the server to your MCP client configuration:
@@ -103,7 +111,8 @@ All settings are controlled via environment variables with the `CODEGUARD_` pref
 
 | Variable | Default | Description |
 |:---------|:--------|:------------|
-| `CODEGUARD_HOST` | `0.0.0.0` | Bind address |
+| `CODEGUARD_HOST` | `0.0.0.0` | Server bind address |
+| `CODEGUARD_PUBLISH_ADDRESS` | `127.0.0.1` | Docker host address for the published port |
 | `CODEGUARD_PORT` | `8080` | Bind port |
 | `CODEGUARD_LOG_LEVEL` | `INFO` | Log level |
 | `CODEGUARD_TRANSPORT` | `streamable-http` | `streamable-http` or `stdio` |

--- a/src/codeguard-mcp/.env.example
+++ b/src/codeguard-mcp/.env.example
@@ -1,5 +1,8 @@
 # CodeGuard MCP Server configuration
 CODEGUARD_HOST=0.0.0.0
+# Docker host address; keep loopback for a proxy on this host. For a remote proxy,
+# use a private interface and restrict the published port to that proxy.
+CODEGUARD_PUBLISH_ADDRESS=127.0.0.1
 CODEGUARD_PORT=8080
 CODEGUARD_LOG_LEVEL=INFO
 # Transport: "streamable-http" (default) or "stdio" for local dev

--- a/src/codeguard-mcp/README.md
+++ b/src/codeguard-mcp/README.md
@@ -26,6 +26,14 @@ cd src/codeguard-mcp
 docker compose up --build
 ```
 
+Docker Compose publishes the server on `127.0.0.1` by default. Keep that default
+when the reverse proxy runs on the Docker host. If the proxy runs on another
+host, set `CODEGUARD_PUBLISH_ADDRESS` to a specific private interface and use
+firewall or security-group rules to allow the published port only from the
+proxy. The proxy must provide TLS and authentication. Do not publish on
+`0.0.0.0` unless equivalent network controls prevent direct access to the
+backend port.
+
 ## Connect Your IDE
 
 Configure your MCP client to connect to the server:
@@ -99,7 +107,8 @@ All settings via environment variables (prefix `CODEGUARD_`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CODEGUARD_HOST` | `0.0.0.0` | Bind address |
+| `CODEGUARD_HOST` | `0.0.0.0` | Server bind address |
+| `CODEGUARD_PUBLISH_ADDRESS` | `127.0.0.1` | Docker host address for the published port |
 | `CODEGUARD_PORT` | `8080` | Bind port |
 | `CODEGUARD_LOG_LEVEL` | `INFO` | Log level |
 | `CODEGUARD_TRANSPORT` | `streamable-http` | `streamable-http` or `stdio` |

--- a/src/codeguard-mcp/docker-compose.yml
+++ b/src/codeguard-mcp/docker-compose.yml
@@ -5,7 +5,9 @@ services:
       dockerfile: src/codeguard-mcp/Dockerfile
     container_name: codeguard-mcp
     ports:
-      - "${CODEGUARD_PORT:-8080}:8080"
+      - target: 8080
+        published: "${CODEGUARD_PORT:-8080}"
+        host_ip: "${CODEGUARD_PUBLISH_ADDRESS:-127.0.0.1}"
     environment:
       - CODEGUARD_LOG_LEVEL=${CODEGUARD_LOG_LEVEL:-INFO}
     read_only: true


### PR DESCRIPTION
Hi,

This is a small patch mainly so that when starting an MCP server with default values, it binds the MCP server to the loopback.
TBH I believe it's simple enough not to need an associated issue first, but I can open one and link this if you prefer.